### PR TITLE
Provide an entitled IBMid while provisioning VM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Build azure-javaee-iaas
         run: mvn -DskipTests clean install --file azure-javaee-iaas/pom.xml
       - name: Build and test
-        run: mvn -Dgit.repo=${{ env.userName }} -DibmUserId=${{ env.unEntitledIbmUserId }} -DibmUserPwd=${{ env.unEntitledIbmPassword }} -DvmName=${{ env.vmName }} -DvmAdminId=${{ env.vmAdminId }} -DvmAdminPwd=${{ env.vmAdminPassword }} -DdnsLabelPrefix=wsp -Dtest.args="-Test All" -Ptemplate-validation-tests clean install --file ${{ env.offerName }}/pom.xml
+        run: mvn -Dgit.repo=${{ env.userName }} -DibmUserId=${{ env.entitledIbmUserId }} -DibmUserPwd=${{ env.entitledIbmPassword }} -DvmName=${{ env.vmName }} -DvmAdminId=${{ env.vmAdminId }} -DvmAdminPwd=${{ env.vmAdminPassword }} -DdnsLabelPrefix=wsp -Dtest.args="-Test All" -Ptemplate-validation-tests clean install --file ${{ env.offerName }}/pom.xml
       - uses: azure/login@v1
         id: azure-login
         with:


### PR DESCRIPTION
An entitled IBMid must be provided to install tWAS while provisioning the VM which is used for creating VM base image.
@zhengchang907 will enhance test cases by adding tWAS installation directory check in another PR.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>