### PR TITLE
Move yum update from extension script to pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,6 +111,14 @@ jobs:
       - name: Create environment variable for VM
         id: env-vm-ip
         run: echo "wlsPublicIP=${{steps.query-vm-ip.outputs.publicIP}}" >> $GITHUB_ENV
+      - name: Update applications
+        run: |
+          echo "pubilc IP of VM: ${wlsPublicIP}"
+          echo "yum update starts"
+          echo install sshpass
+          sudo apt-get install -y sshpass
+          timeout 1m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${wlsPublicIP} 22
+          sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S yum update -y'
       - name: Deprovision
         run: |
           echo "pubilc IP of VM: ${wlsPublicIP}"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 1. Build the project by replacing all placeholder `${<place_holder>}` with valid values
 
    ```bash
-   mvn -Dgit.repo=<repo_user> -Dgit.tag=<repo_tag> -DibmUserId=<ibmUserId> -DibmUserPwd=<ibmUserPwd> -DvmAdminId=<vmAdminId> -DvmAdminPwd=<vmAdminPwd> -DdnsLabelPrefix=<dnsLabelPrefix> -Dtest.args="-Test All" -Ptemplate-validation-tests clean install
+   mvn -Dgit.repo=<repo_user> -Dgit.tag=<repo_tag> -DibmUserId=<entitledIBMid> -DibmUserPwd=<entitledIBMidPwd> -DvmAdminId=<vmAdminId> -DvmAdminPwd=<vmAdminPwd> -DdnsLabelPrefix=<dnsLabelPrefix> -Dtest.args="-Test All" -Ptemplate-validation-tests clean install
    ```
 
 1. Change to `./target/arm` directory
@@ -41,7 +41,8 @@
 1. [Generate VM image](https://docs.microsoft.com/azure/virtual-machines/linux/capture-image):
    1. SSH into the provisioned VM
       1. Delete all sensitive files that you don't want them appear in image
-      1. `sudo waagent -deprovision+user -force`
+      1. Update applications installed on the system: `sudo yum update -y`
+      1. Deprovision: `sudo waagent -deprovision+user -force`
       1. exit
    1. De-allocate VM: `az vm deallocate --resource-group <resourceGroupName> --name <vmName>`
    1. Generalize VM: `az vm generalize --resource-group <resourceGroupName> --name <vmName>`

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -36,9 +36,6 @@ done
 name=$(df -h | grep "/datadrive" | awk '{print $1;}' | grep -Po "(?<=\/dev\/).*")
 echo "UUID=$(blkid | grep -Po "(?<=\/dev\/${name}\: UUID=\")[^\"]*(?=\".*)")   /datadrive   xfs   defaults,nofail   1   2" >> /etc/fstab
 
-# Update applications installed on the system
-yum update -y
-
 # Move tWAS entitlement check and application patch script to /var/lib/cloud/scripts/per-instance
 mv was-check.sh /var/lib/cloud/scripts/per-instance
 


### PR DESCRIPTION
The latest run of pipeline failed. During my investigation, I found that it failed due to it hangs at execution of  extension script, especially the following step when executing `yum update -y`:
* ![image](https://user-images.githubusercontent.com/10357495/118822185-85b4aa80-b8ea-11eb-9bae-bd0e20a7d35e.png)

The WALinuxAgent is the agent to execute the extension script, so it's obvious that it may cause issue if WALinuxAgent is upgraded during the execution of extension script.

The solution of the PR is moving `yum update` from extension script to pipeline.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>