### PR TITLE
parameterize and upgrade api version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,5 +33,7 @@
     <name>${project.artifactId}</name>
 
     <properties>
+        <azure.apiVersion>2020-06-01</azure.apiVersion>
+        <azure.apiVersion2>2019-06-01</azure.apiVersion2>
     </properties>
 </project>

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -97,7 +97,7 @@ sudo mkdir /datadrive && sudo mount /dev/${disk}1 /datadrive",
     "resources": [
         {
             "type": "Microsoft.Network/networkSecurityGroups",
-            "apiVersion": "2019-06-01",
+            "apiVersion": "${azure.apiVersion}",
             "name": "[variables('name_networkSecurityGroup')]",
             "location": "[parameters('location')]",
             "properties": {
@@ -122,7 +122,7 @@ sudo mkdir /datadrive && sudo mount /dev/${disk}1 /datadrive",
         },
         {
             "type": "Microsoft.Network/virtualNetworks",
-            "apiVersion": "2019-06-01",
+            "apiVersion": "${azure.apiVersion}",
             "name": "[variables('name_virtualNetwork')]",
             "location": "[parameters('location')]",
             "dependsOn": [
@@ -140,7 +140,7 @@ sudo mkdir /datadrive && sudo mount /dev/${disk}1 /datadrive",
         },
         {
             "type": "Microsoft.Network/virtualNetworks/subnets",
-            "apiVersion": "2019-06-01",
+            "apiVersion": "${azure.apiVersion}",
             "name": "[concat(variables('name_virtualNetwork'), '/', parameters('subnetName'))]",
             "dependsOn": [
                 "[variables('ref_virtualNetwork')]",
@@ -155,7 +155,7 @@ sudo mkdir /datadrive && sudo mount /dev/${disk}1 /datadrive",
         },                
         {
             "type": "Microsoft.Network/publicIPAddresses",
-            "apiVersion": "2019-06-01",
+            "apiVersion": "${azure.apiVersion}",
             "name": "[variables('name_publicIPAddress')]",
             "location": "[parameters('location')]",
             "properties": {
@@ -167,7 +167,7 @@ sudo mkdir /datadrive && sudo mount /dev/${disk}1 /datadrive",
         },
         {
             "type": "Microsoft.Network/networkInterfaces",
-            "apiVersion": "2019-06-01",
+            "apiVersion": "${azure.apiVersion}",
             "name": "[variables('name_networkInterface')]",
             "location": "[parameters('location')]",
             "dependsOn": [
@@ -197,7 +197,7 @@ sudo mkdir /datadrive && sudo mount /dev/${disk}1 /datadrive",
         {
             "name": "[variables('name_storageAccount')]",
             "type": "Microsoft.Storage/storageAccounts",
-            "apiVersion": "2019-06-01",
+            "apiVersion": "${azure.apiVersion2}",
             "location": "[parameters('location')]",
             "properties": {},
             "kind": "Storage",
@@ -207,7 +207,7 @@ sudo mkdir /datadrive && sudo mount /dev/${disk}1 /datadrive",
         },
         {
             "type": "Microsoft.Compute/virtualMachines",
-            "apiVersion": "2020-06-01",
+            "apiVersion": "${azure.apiVersion}",
             "name": "[variables('name_virtualMachine')]",
             "location": "[parameters('location')]",
             "dependsOn": [
@@ -264,7 +264,7 @@ sudo mkdir /datadrive && sudo mount /dev/${disk}1 /datadrive",
         },
         {
             "type": "Microsoft.Compute/virtualMachines/extensions",
-            "apiVersion": "2020-06-01",
+            "apiVersion": "${azure.apiVersion}",
             "name": "[concat(variables('name_virtualMachine'), '/CustomScript')]",
             "location": "[parameters('location')]",
             "dependsOn": [


### PR DESCRIPTION
Fix the following arm-ttk unit test issue:

- API version 2019-06-01 of Microsoft.Network/networkSecurityGroups is 738 days

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>