### PR TITLE
Update Azure CLI version and add additional validations

### DIFF
--- a/.github/workflows/twasBuild.yml
+++ b/.github/workflows/twasBuild.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   # Latest version is at https://github.com/Azure/azure-cli/releases
-  azCliVersion: 2.6.0
+  azCliVersion: 2.23.0
   # Commit hash from https://github.com/Azure/azure-javaee-iaas/commits/main
   ref_javaee: 6addd99d8bc3f472e040f11c053a37e1ac370229
   # Commit hash from https://github.com/Azure/arm-ttk/commits/master
@@ -33,6 +33,8 @@ env:
   vhdStorageAccountName: storage${{ github.run_id }}${{ github.run_number }}
   msTeamsWebhook: ${{ secrets.MSTEAMS_WEBHOOK }}
   location: eastus
+  # Installation directory, must be updated if virtualimage.properties/WAS_ND_INSTALL_DIRECTORY changed 
+  was_nd_install_directory: /datadrive/IBM/WebSphere/ND/V9
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -188,6 +190,15 @@ jobs:
           if [ ${result} = Entitled ]; then
               exit 1
           fi
+
+          # Check the installation path is not removed
+          echo "Check the installation path is not removed"
+          pathExists=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${untitledVMIP} 'if [ -d "${{ env.was_nd_install_directory }}" ]; then echo true; else echo false; fi')
+          if [[ $pathExists = true ]]; then
+            echo "IBM installations still exist"
+            exit 1
+          fi
+
       - name: Deploy VM using image with entitled account
         run: |
           imageResourceId=$(az image show --name ${{ env.vmName }} --resource-group ${{ env.testResourceGroup }} --query id -o tsv)
@@ -238,6 +249,15 @@ jobs:
           if [ ${result} = Unentitled ]; then
               exit 1
           fi
+          
+          # Check the installation path is removed
+          echo "Check the installation path is removed"
+          pathExists=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} 'if [ -d "${{ env.was_nd_install_directory }}" ]; then echo true; else echo false; fi')
+          if [[ $pathExists = false ]]; then
+            echo "IBM installations do not exist"
+            exit 1
+          fi
+
       - name: Delete all resources but vhd storage account in the test resource group
         id: delete-resources-in-group
         if: always()

--- a/twas-nd/src/main/scripts/install.sh
+++ b/twas-nd/src/main/scripts/install.sh
@@ -54,6 +54,22 @@ mkdir im_installer
 unzip -q "$IM_INSTALL_KIT" -d im_installer
 ./im_installer/userinstc -log log_file -acceptLicense -installationDirectory ${IM_INSTALL_DIRECTORY}
 
+# Check whether IBMid is entitled or not
+${IM_INSTALL_DIRECTORY}/eclipse/tools/imutilsc saveCredential -secureStorageFile storage_file \
+    -userName "$userName" -userPassword "$password" -passportAdvantage
+if [ $? -eq 0 ]; then
+    output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl listAvailablePackages -cPA -secureStorageFile storage_file)
+    if echo "$output" | grep "$WAS_ND_VERSION_ENTITLED"; then
+        echo "IBM account entitlement check succeed."
+    else
+        echo "IBM account entitlement check failed."
+        exit 1
+    fi
+else
+    echo "Cannot connect to Passport Advantage."
+    exit 1
+fi
+
 # Install IBM WebSphere Application Server Network Deployment V9 using IBM Instalation Manager
 ${IM_INSTALL_DIRECTORY}/eclipse/tools/imutilsc saveCredential -secureStorageFile storage_file \
     -userName "$userName" -userPassword "$password" -passportAdvantage

--- a/twas-nd/src/main/scripts/virtualimage.properties
+++ b/twas-nd/src/main/scripts/virtualimage.properties
@@ -11,8 +11,8 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-WAS_ND_TRADITIONAL=com.ibm.websphere.ND.v90_9.0.5007.20210301_1241
-IBM_JAVA_SDK=com.ibm.java.jdk.v8_8.0.6026.20210226_0840
+WAS_ND_TRADITIONAL=com.ibm.websphere.ND.v90
+IBM_JAVA_SDK=com.ibm.java.jdk.v8
 REPOSITORY_URL=https://www.ibm.com/software/repositorymanager/entitled
 WAS_ND_VERSION_ENTITLED=ND.v90_9.0.5007
 IM_INSTALL_KIT=agent.installer.linux.gtk.x86_64.zip


### PR DESCRIPTION
### Description
This PR is to address [Issue 20](https://github.com/WASdev/azure.websphere-traditional.image/issues/20) and [Issue 26](https://github.com/WASdev/azure.websphere-traditional.image/issues/26)
### Change Summary
* Update Azure CLI version to resolve [Issue 20](https://github.com/WASdev/azure.websphere-traditional.image/issues/20)
* Add additional step in pipeline to verify the installation directory's existence based on difference account entitlement status, [Issue 26](https://github.com/WASdev/azure.websphere-traditional.image/issues/26)
* Add entitlement check in install.sh to fail fast if the user account is unentitled. [Issue 26](https://github.com/WASdev/azure.websphere-traditional.image/issues/26)

### Test Case
* Happy pass: https://github.com/zhengchang907/azure.websphere-traditional.image/actions/runs/938536230
* Local deployment using unentitled account and the template deployment failed

Signed-off-by: Zheng Chang <zhengchang@microsoft.com>