### PR TITLE
Add WAS_ND_INSTALL_DIRECTORY property to IHS virtualimage.properties

### DIFF
--- a/ihs/src/main/scripts/virtualimage.properties
+++ b/ihs/src/main/scripts/virtualimage.properties
@@ -15,6 +15,7 @@ IM_INSTALL_KIT=agent.installer.linux.gtk.x86_64.zip
 IM_INSTALL_KIT_URL=https://public.dhe.ibm.com/ibmdl/export/pub/software/im/zips/${IM_INSTALL_KIT}
 IM_INSTALL_DIRECTORY=/datadrive/IBM/InstallationManager/V1.9
 IM_SHARED_DIRECTORY=/datadrive/IBM/IMShared
+WAS_ND_INSTALL_DIRECTORY=/datadrive/IBM/WebSphere/ND/V9
 WAS_ND_VERSION_ENTITLED=ND.v90_9.0.5007
 REPOSITORY_URL=https://www.ibm.com/software/repositorymanager/entitled
 IBM_HTTP_SERVER=com.ibm.websphere.IHS.v90


### PR DESCRIPTION
This is required as part of solution to address https://github.com/WASdev/azure.websphere-traditional.cluster/issues/48.

- Add WAS_ND_INSTALL_DIRECTORY property to IHS virtualimage.properties with the same value as DMgr, see the 2nd note from Ranjan's comment in https://github.com/WASdev/azure.websphere-traditional.cluster/issues/48#issuecomment-867191495.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>