### PR TITLE
Remove '-start' of deprovision command to fix timing issue

### DIFF
--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -132,7 +132,7 @@ jobs:
           echo install sshpass
           sudo apt-get install -y sshpass
           timeout 1m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${wlsPublicIP} 22
-          sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S waagent -deprovision+user -force -start'
+          sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S waagent -deprovision+user -force'
       - name: Generate VM Image
         run: |
           # Update the access level of vhd container

--- a/.github/workflows/twas-ndBuild.yml
+++ b/.github/workflows/twas-ndBuild.yml
@@ -130,7 +130,7 @@ jobs:
           echo install sshpass
           sudo apt-get install -y sshpass
           timeout 1m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${wlsPublicIP} 22
-          sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S waagent -deprovision+user -force -start'
+          sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S waagent -deprovision+user -force'
       - name: Generate VM Image
         run: |
           # Update the access level of vhd container


### PR DESCRIPTION
The **'-start'** param(Run waagent as a background process) of deprovision command'waagent -deprovision+user -force -start' will cause the deprovision **NOT EXECUTE** via ssh calls, so it needs to be removed.

Verified on forked repo by manually ssh to the VMs deployed using generated images to see if the user related data is removed.
twas-nd: https://github.com/zhengchang907/azure.websphere-traditional.image/runs/2929156017?check_suite_focus=true
ihs: https://github.com/zhengchang907/azure.websphere-traditional.image/actions/runs/978035653

Signed-off-by: Zheng Chang <zhengchang@microsoft.com>