### PR TITLE
Upgrade to rhel 8_4

### DIFF
--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -269,32 +269,6 @@ jobs:
             echo "IBM installations do not exist"
             exit 1
           fi
-
-      - name: Delete all resources but vhd storage account in the test resource group
-        id: delete-resources-in-group
-        if: always()
-        uses: azure/CLI@v1
-        with:
-          azcliversion: ${{ env.azCliVersion }}
-          inlineScript: |
-            # Disks have to be deleted after the VM is deleted
-            unentitledOsDiskId=$(az vm show --resource-group ${{ env.testResourceGroup }} --name unentitled${{ github.run_id }}${{ github.run_number }} --query "storageProfile.osDisk.managedDisk.id" -o tsv)
-            echo "unentitledOsDiskId: ${unentitledOsDiskId}"
-
-            unentitledDataDiskIds=$(az vm show --resource-group ${{ env.testResourceGroup }} --name unentitled${{ github.run_id }}${{ github.run_number }} --query "storageProfile.dataDisks" | jq -r 'map(.managedDisk.id) | join(" ")')
-            echo "unentitledDataDiskIds: ${unentitledDataDiskIds}"
-
-            entitledOsDiskId=$(az vm show --resource-group ${{ env.testResourceGroup }} --name entitled${{ github.run_id }}${{ github.run_number }} --query "storageProfile.osDisk.managedDisk.id" -o tsv)
-            echo "unentitledOsDiskId: ${unentitledOsDiskId}"
-
-            entitledDataDiskIds=$(az vm show --resource-group ${{ env.testResourceGroup }} --name entitled${{ github.run_id }}${{ github.run_number }} --query "storageProfile.dataDisks" | jq -r 'map(.managedDisk.id) | join(" ")')
-            echo "unentitledDataDiskIds: ${unentitledDataDiskIds}"
-
-            resourcesToDelete=$(az resource list --query "[?name!='${{ env.vhdStorageAccountName }}']" --resource-group ${{ env.testResourceGroup }} | jq -r 'map(.id) | join(" ")')
-            echo $resourcesToDelete
-
-            az resource delete --verbose --ids $resourcesToDelete
-            az disk delete --yes --resource-group ${{ env.testResourceGroup }} --ids ${unentitledOsDiskId} ${unentitledDataDiskIds} ${entitledOsDiskId} ${entitledDataDiskIds}
       - name: Generate SAS url
         id: generate-sas-blob-url
         run: |
@@ -328,6 +302,36 @@ jobs:
         with:
           name: sasurl
           path: sas-url.txt
+
+      - name: Delete all resources but vhd storage account in the test resource group
+        id: delete-resources-in-group
+        if: always()
+        uses: azure/CLI@v1
+        with:
+          azcliversion: ${{ env.azCliVersion }}
+          inlineScript: |
+            # Disks have to be deleted after the VM is deleted
+            unentitledOsDiskId=$(az vm show --resource-group ${{ env.testResourceGroup }} --name unentitled${{ github.run_id }}${{ github.run_number }} --query "storageProfile.osDisk.managedDisk.id" -o tsv)
+            echo "unentitledOsDiskId: ${unentitledOsDiskId}"
+
+            unentitledDataDiskIds=$(az vm show --resource-group ${{ env.testResourceGroup }} --name unentitled${{ github.run_id }}${{ github.run_number }} --query "storageProfile.dataDisks" | jq -r 'map(.managedDisk.id) | join(" ")')
+            echo "unentitledDataDiskIds: ${unentitledDataDiskIds}"
+
+            entitledOsDiskId=$(az vm show --resource-group ${{ env.testResourceGroup }} --name entitled${{ github.run_id }}${{ github.run_number }} --query "storageProfile.osDisk.managedDisk.id" -o tsv)
+            echo "unentitledOsDiskId: ${unentitledOsDiskId}"
+
+            entitledDataDiskIds=$(az vm show --resource-group ${{ env.testResourceGroup }} --name entitled${{ github.run_id }}${{ github.run_number }} --query "storageProfile.dataDisks" | jq -r 'map(.managedDisk.id) | join(" ")')
+            echo "unentitledDataDiskIds: ${unentitledDataDiskIds}"
+
+            vmForImage=$(az vm list --resource-group ${{ env.testResourceGroup }} --query "[?name=='${{ env.vmName }}']" | jq -r 'map(.id) | join(" ")')
+            echo $vmForImage
+
+            resourcesToDelete=$(az resource list --query "[?name!='${{ env.vhdStorageAccountName }}']" --resource-group ${{ env.testResourceGroup }} | jq -r 'map(.id) | join(" ")')
+            echo $resourcesToDelete
+
+            az vm delete --verbose --ids $vmForImage --yes
+            az resource delete --verbose --ids $resourcesToDelete
+            az disk delete --yes --resource-group ${{ env.testResourceGroup }} --ids ${unentitledOsDiskId} ${unentitledDataDiskIds} ${entitledOsDiskId} ${entitledDataDiskIds}
   summary:
     needs: build
     if: always()

--- a/.github/workflows/twas-ndBuild.yml
+++ b/.github/workflows/twas-ndBuild.yml
@@ -267,32 +267,6 @@ jobs:
             echo "IBM installations do not exist"
             exit 1
           fi
-
-      - name: Delete all resources but vhd storage account in the test resource group
-        id: delete-resources-in-group
-        if: always()
-        uses: azure/CLI@v1
-        with:
-          azcliversion: ${{ env.azCliVersion }}
-          inlineScript: |
-            # Disks have to be deleted after the VM is deleted
-            unentitledOsDiskId=$(az vm show --resource-group ${{ env.testResourceGroup }} --name unentitled${{ github.run_id }}${{ github.run_number }} --query "storageProfile.osDisk.managedDisk.id" -o tsv)
-            echo "unentitledOsDiskId: ${unentitledOsDiskId}"
-
-            unentitledDataDiskIds=$(az vm show --resource-group ${{ env.testResourceGroup }} --name unentitled${{ github.run_id }}${{ github.run_number }} --query "storageProfile.dataDisks" | jq -r 'map(.managedDisk.id) | join(" ")')
-            echo "unentitledDataDiskIds: ${unentitledDataDiskIds}"
-
-            entitledOsDiskId=$(az vm show --resource-group ${{ env.testResourceGroup }} --name entitled${{ github.run_id }}${{ github.run_number }} --query "storageProfile.osDisk.managedDisk.id" -o tsv)
-            echo "unentitledOsDiskId: ${unentitledOsDiskId}"
-
-            entitledDataDiskIds=$(az vm show --resource-group ${{ env.testResourceGroup }} --name entitled${{ github.run_id }}${{ github.run_number }} --query "storageProfile.dataDisks" | jq -r 'map(.managedDisk.id) | join(" ")')
-            echo "unentitledDataDiskIds: ${unentitledDataDiskIds}"
-
-            resourcesToDelete=$(az resource list --query "[?name!='${{ env.vhdStorageAccountName }}']" --resource-group ${{ env.testResourceGroup }} | jq -r 'map(.id) | join(" ")')
-            echo $resourcesToDelete
-
-            az resource delete --verbose --ids $resourcesToDelete
-            az disk delete --yes --resource-group ${{ env.testResourceGroup }} --ids ${unentitledOsDiskId} ${unentitledDataDiskIds} ${entitledOsDiskId} ${entitledDataDiskIds}
       - name: Generate SAS url
         id: generate-sas-blob-url
         run: |
@@ -326,6 +300,36 @@ jobs:
         with:
           name: sasurl
           path: sas-url.txt
+
+      - name: Delete all resources but vhd storage account in the test resource group
+        id: delete-resources-in-group
+        if: always()
+        uses: azure/CLI@v1
+        with:
+          azcliversion: ${{ env.azCliVersion }}
+          inlineScript: |
+            # Disks have to be deleted after the VM is deleted
+            unentitledOsDiskId=$(az vm show --resource-group ${{ env.testResourceGroup }} --name unentitled${{ github.run_id }}${{ github.run_number }} --query "storageProfile.osDisk.managedDisk.id" -o tsv)
+            echo "unentitledOsDiskId: ${unentitledOsDiskId}"
+
+            unentitledDataDiskIds=$(az vm show --resource-group ${{ env.testResourceGroup }} --name unentitled${{ github.run_id }}${{ github.run_number }} --query "storageProfile.dataDisks" | jq -r 'map(.managedDisk.id) | join(" ")')
+            echo "unentitledDataDiskIds: ${unentitledDataDiskIds}"
+
+            entitledOsDiskId=$(az vm show --resource-group ${{ env.testResourceGroup }} --name entitled${{ github.run_id }}${{ github.run_number }} --query "storageProfile.osDisk.managedDisk.id" -o tsv)
+            echo "unentitledOsDiskId: ${unentitledOsDiskId}"
+
+            entitledDataDiskIds=$(az vm show --resource-group ${{ env.testResourceGroup }} --name entitled${{ github.run_id }}${{ github.run_number }} --query "storageProfile.dataDisks" | jq -r 'map(.managedDisk.id) | join(" ")')
+            echo "unentitledDataDiskIds: ${unentitledDataDiskIds}"
+
+            vmForImage=$(az vm list --resource-group ${{ env.testResourceGroup }} --query "[?name=='${{ env.vmName }}']" | jq -r 'map(.id) | join(" ")')
+            echo $vmForImage
+
+            resourcesToDelete=$(az resource list --query "[?name!='${{ env.vhdStorageAccountName }}']" --resource-group ${{ env.testResourceGroup }} | jq -r 'map(.id) | join(" ")')
+            echo $resourcesToDelete
+
+            az vm delete --verbose --ids $vmForImage --yes
+            az resource delete --verbose --ids $resourcesToDelete
+            az disk delete --yes --resource-group ${{ env.testResourceGroup }} --ids ${unentitledOsDiskId} ${unentitledDataDiskIds} ${entitledOsDiskId} ${entitledDataDiskIds}
   summary:
     needs: build
     if: always()

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Deploy an Azure VM with RHEL 8.3, IBM HTTP Server V9.0 & IBM JDK 8.0 pre-installed](/ihs)
-# [Deploy an Azure VM with RHEL 8.3, IBM WebSphere Application Server ND Traditional V9.0.5 & IBM JDK 8.0 pre-installed](/twas-nd)
-# [Related: Deploy RHEL 8.3 VMs on Azure with IBM WebSphere Application Server ND Traditional V9.0.5 cluster pre-installed](https://github.com/WASdev/azure.websphere-traditional.cluster)
+# [Deploy an Azure VM with RHEL 8.4, IBM HTTP Server V9.0 & IBM JDK 8.0 pre-installed](/ihs)
+# [Deploy an Azure VM with RHEL 8.4, IBM WebSphere Application Server ND Traditional V9.0.5 & IBM JDK 8.0 pre-installed](/twas-nd)
+# [Related: Deploy RHEL 8.4 VMs on Azure with IBM WebSphere Application Server ND Traditional V9.0.5 cluster pre-installed](https://github.com/WASdev/azure.websphere-traditional.cluster)
 # [Issues](https://github.com/WASdev/azure.websphere-traditional.cluster/issues)

--- a/config.properties
+++ b/config.properties
@@ -1,0 +1,21 @@
+#      Copyright (c) Microsoft Corporation.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+# 
+#           http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+image.publisher=RedHat
+image.offer=RHEL
+image.sku=8_4
+image.version=latest
+
+azure.apiVersion=2020-06-01
+azure.apiVersion2=2019-06-01

--- a/ihs/README.md
+++ b/ihs/README.md
@@ -1,4 +1,4 @@
-# Deploy an Azure VM with RHEL 8.3, IBM HTTP Server V9.0, Plugin, WCT & IBM JDK 8.0 pre-installed
+# Deploy an Azure VM with RHEL 8.4, IBM HTTP Server V9.0, Plugin, WCT & IBM JDK 8.0 pre-installed
 
 ## Prerequisites
 
@@ -31,12 +31,12 @@
 
 ## After deployment
 
-1. You can [capture the source VM to a custom image](https://docs.microsoft.com/azure/virtual-machines/linux/capture-image), which consists of RHEL 8.3, IBM WebSphere Application Server ND Traditional V9.0.5 & IBM JDK 8.0, so it can be reused to create VM instances based on it using the same subscription;
+1. You can [capture the source VM to a custom image](https://docs.microsoft.com/azure/virtual-machines/linux/capture-image), which consists of RHEL 8.4, IBM WebSphere Application Server ND Traditional V9.0.5 & IBM JDK 8.0, so it can be reused to create VM instances based on it using the same subscription;
 1. Similar to creating a custom private image, you can also [create a Virtual Machine offer in Azure Marketplace](https://docs.microsoft.com/azure/marketplace/cloud-partner-portal/virtual-machine/cpp-virtual-machine-offer), which is globally public and accessible. You can see more information in the following section.
 
 ### Creating Virtual Machine offer in Azure Marketplace manually
 
-1. Deploy an Azure VM provisioned with RHEL, IHS & JDK (RHEL 8.3, IBM HTTP Server V9.0, Plugin, WCT & IBM JDK 8.0) by following [Steps of deployment](#steps-of-deployment)
+1. Deploy an Azure VM provisioned with RHEL, IHS & JDK (RHEL 8.4, IBM HTTP Server V9.0, Plugin, WCT & IBM JDK 8.0) by following [Steps of deployment](#steps-of-deployment)
 1. [Generate VM image](https://docs.microsoft.com/azure/virtual-machines/linux/capture-image):
    1. SSH into the provisioned VM
       1. Update applications installed on the system: `sudo yum update -y`

--- a/ihs/pom.xml
+++ b/ihs/pom.xml
@@ -35,6 +35,11 @@
     <properties>
         <git.proj>azure.websphere-traditional.image</git.proj>
         <git.repo>WASdev</git.repo>
+        <!-- 
+            The default value for `git.tag` is defined in parent pom "azure-javaee-iaas-parent", which is `master`.
+            It can also be overridden with `-Dgit.tag` at the maven command line if you use a different git branch.
+            See https://github.com/Azure/azure-javaee-iaas/blob/main/arm-parent/pom.xml#L22-L24 for more available properties.
+         -->
         <template.pid.properties.url>${artifactsLocationBase}/${git.proj}/${git.tag}/config.properties</template.pid.properties.url>
     </properties>
 </project>

--- a/ihs/pom.xml
+++ b/ihs/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <git.proj>azure.websphere-traditional.image</git.proj>
-        <azure.apiVersion>2020-06-01</azure.apiVersion>
-        <azure.apiVersion2>2019-06-01</azure.apiVersion2>
+        <git.repo>WASdev</git.repo>
+        <template.pid.properties.url>${artifactsLocationBase}/${git.proj}/${git.tag}/config.properties</template.pid.properties.url>
     </properties>
 </project>

--- a/ihs/src/main/arm/mainTemplate.json
+++ b/ihs/src/main/arm/mainTemplate.json
@@ -225,7 +225,7 @@ sudo mkdir /datadrive && sudo mount /dev/${disk}1 /datadrive",
                     "imageReference": {
                         "publisher": "RedHat",
                         "offer": "RHEL",
-                        "sku": "8_3",
+                        "sku": "8_4",
                         "version": "latest"
                     },
                     "osDisk": {

--- a/ihs/src/main/arm/mainTemplate.json
+++ b/ihs/src/main/arm/mainTemplate.json
@@ -223,10 +223,10 @@ sudo mkdir /datadrive && sudo mount /dev/${disk}1 /datadrive",
                 },
                 "storageProfile": {
                     "imageReference": {
-                        "publisher": "RedHat",
-                        "offer": "RHEL",
-                        "sku": "8_4",
-                        "version": "latest"
+                        "publisher": "${image.publisher}",
+                        "offer": "${image.offer}",
+                        "sku": "${image.sku}",
+                        "version": "${image.version}"
                     },
                     "osDisk": {
                         "name": "[concat(variables('name_virtualMachine'), '-disk')]",

--- a/ihs/src/main/resources/marketing-artifacts/README.md
+++ b/ihs/src/main/resources/marketing-artifacts/README.md
@@ -109,7 +109,7 @@
       
    * OS friendly name
    
-      RHEL_8_3
+      RHEL_8_4
       
 * Recommended VM sizes
 

--- a/twas-nd/README.md
+++ b/twas-nd/README.md
@@ -1,4 +1,4 @@
-# Deploy an Azure VM with RHEL 8.3, IBM WebSphere Application Server ND Traditional V9.0.5 & IBM JDK 8.0 pre-installed
+# Deploy an Azure VM with RHEL 8.4, IBM WebSphere Application Server ND Traditional V9.0.5 & IBM JDK 8.0 pre-installed
 
 ## Prerequisites
 
@@ -31,12 +31,12 @@
 
 ## After deployment
 
-1. You can [capture the source VM to a custom image](https://docs.microsoft.com/azure/virtual-machines/linux/capture-image), which consists of RHEL 8.3, IBM WebSphere Application Server ND Traditional V9.0.5 & IBM JDK 8.0, so it can be reused to create VM instances based on it using the same subscription;
+1. You can [capture the source VM to a custom image](https://docs.microsoft.com/azure/virtual-machines/linux/capture-image), which consists of RHEL 8.4, IBM WebSphere Application Server ND Traditional V9.0.5 & IBM JDK 8.0, so it can be reused to create VM instances based on it using the same subscription;
 1. Similar to creating a custom private image, you can also [create a Virtual Machine offer in Azure Marketplace](https://docs.microsoft.com/azure/marketplace/cloud-partner-portal/virtual-machine/cpp-virtual-machine-offer), which is globally public and accessible. You can see more information in the following section.
 
 ### Creating Virtual Machine offer in Azure Marketplace manually
 
-1. Deploy an Azure VM provisioned with RHEL, WebSphere & JDK (e.g., RHEL 8.3, IBM WebSphere Application Server ND Traditional V9.0.5 & IBM JDK 8.0). Use different combinations of OS, WebSphere and JDK per your requirements. If you want to install WebSphere and JDK in a separate data disk, only provision the VM with RHEL. Manual deployment or using the tailored ARM template works.
+1. Deploy an Azure VM provisioned with RHEL, WebSphere & JDK (e.g., RHEL 8.4, IBM WebSphere Application Server ND Traditional V9.0.5 & IBM JDK 8.0). Use different combinations of OS, WebSphere and JDK per your requirements. If you want to install WebSphere and JDK in a separate data disk, only provision the VM with RHEL. Manual deployment or using the tailored ARM template works.
    1. Use un-managed disks instead of managed disks for VM provision. By doing so, the VHDs attached to the VM are stored in the storage account, which can be accessed later during the certification process of publishing VM image into Azure Marketplace
    1. This repo is an example on how to create an un-managed OS disk and data disk in the storage account using ARM template;
 1. [Generate VM image](https://docs.microsoft.com/azure/virtual-machines/linux/capture-image):

--- a/twas-nd/pom.xml
+++ b/twas-nd/pom.xml
@@ -33,7 +33,7 @@
     <name>${project.artifactId}</name>
 
     <properties>
-        <azure.apiVersion>2020-06-01</azure.apiVersion>
-        <azure.apiVersion2>2019-06-01</azure.apiVersion2>
+        <git.repo>WASdev</git.repo>
+        <template.pid.properties.url>${artifactsLocationBase}/${project.artifactId}/${git.tag}/config.properties</template.pid.properties.url>
     </properties>
 </project>

--- a/twas-nd/pom.xml
+++ b/twas-nd/pom.xml
@@ -34,6 +34,11 @@
 
     <properties>
         <git.repo>WASdev</git.repo>
+        <!-- 
+            The default value for `git.tag` is defined in parent pom "azure-javaee-iaas-parent", which is `master`.
+            It can also be overridden with `-Dgit.tag` at the maven command line if you use a different git branch.
+            See https://github.com/Azure/azure-javaee-iaas/blob/main/arm-parent/pom.xml#L22-L24 for more available properties.
+         -->
         <template.pid.properties.url>${artifactsLocationBase}/${project.artifactId}/${git.tag}/config.properties</template.pid.properties.url>
     </properties>
 </project>

--- a/twas-nd/src/main/arm/mainTemplate.json
+++ b/twas-nd/src/main/arm/mainTemplate.json
@@ -225,7 +225,7 @@ sudo mkdir /datadrive && sudo mount /dev/${disk}1 /datadrive",
                     "imageReference": {
                         "publisher": "RedHat",
                         "offer": "RHEL",
-                        "sku": "8_3",
+                        "sku": "8_4",
                         "version": "latest"
                     },
                     "osDisk": {

--- a/twas-nd/src/main/arm/mainTemplate.json
+++ b/twas-nd/src/main/arm/mainTemplate.json
@@ -223,10 +223,10 @@ sudo mkdir /datadrive && sudo mount /dev/${disk}1 /datadrive",
                 },
                 "storageProfile": {
                     "imageReference": {
-                        "publisher": "RedHat",
-                        "offer": "RHEL",
-                        "sku": "8_4",
-                        "version": "latest"
+                        "publisher": "${image.publisher}",
+                        "offer": "${image.offer}",
+                        "sku": "${image.sku}",
+                        "version": "${image.version}"
                     },
                     "osDisk": {
                         "name": "[concat(variables('name_virtualMachine'), '-disk')]",

--- a/twas-nd/src/main/resources/marketing-artifacts/README.md
+++ b/twas-nd/src/main/resources/marketing-artifacts/README.md
@@ -119,7 +119,7 @@ The currently available offers are listed in the Learn More section at the botto
       
    * OS friendly name
    
-      RHEL_8_3
+      RHEL_8_4
       
 * Recommended VM sizes
 


### PR DESCRIPTION
## Change summary

The PR is to upgrade RHEL version of the base images from 8_3 to 8_4, which resolves the following issues:
* Fix WASdev/azure.websphere-traditional.cluster/issues/88
* Fix WASdev/azure.websphere-traditional.cluster/issues/89
* [Improve robustness of the pipeline](https://github.com/majguo/azure.websphere-traditional.image/pull/4)

## Testing

The following test cases are passed using the private VM images generated by the source branch of the PR:
* Successfully deployed a static cluster with 1 worker node and 1 IHS, using the entitled IBM ID. Verified that the cluster and IHS works by visiting the installed `DefaultApplication` using IP address of IHS VM.
* Successfully deployed a dynamic cluster with 1 worker node and 1 IHS, using the entitled IBM ID. Verified that the cluster and IHS works by visiting the installed `DefaultApplication` using IP address of IHS VM.
* Deployed a cluster with 1 worker node and 1 IHS, using the invalid IBM ID. Verified that all VMs are emptied.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>