### PR TITLE
Move utility scripts to src/main/cli

### DIFF
--- a/ihs/README.md
+++ b/ihs/README.md
@@ -22,7 +22,7 @@
    mvn -Dgit.repo=<repo_user> -Dgit.tag=<repo_tag> -DibmUserId=<entitledIBMid> -DibmUserPwd=<entitledIBMidPwd> -DvmAdminId=<vmAdminId> -DvmAdminPwd=<vmAdminPwd> -DdnsLabelPrefix=<dnsLabelPrefix> -Dtest.args="-Test All" -Ptemplate-validation-tests -Dtemplate.validation.tests.directory=../../arm-ttk/arm-ttk clean install
    ```
 
-1. Change to `./target/arm` directory
+1. Change to `./target/cli` directory
 1. Using `deploy.azcli` to deploy
 
    ```bash

--- a/ihs/pom.xml
+++ b/ihs/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>
         <artifactId>azure-javaee-iaas-parent</artifactId>
-        <version>1.0.7</version>
+        <version>1.0.11</version>
         <relativePath></relativePath>
     </parent>
     

--- a/ihs/src/main/cli/deploy.azcli
+++ b/ihs/src/main/cli/deploy.azcli
@@ -82,7 +82,7 @@ if [ -z "$deploymentName" ] || [ -z "$subscriptionId" ] || [ -z "$resourceGroupN
 fi
 
 #templateFile Path - template file to be used
-templateFilePath="./mainTemplate.json"
+templateFilePath="../arm/mainTemplate.json"
 
 if [ ! -f "$templateFilePath" ]; then
 	echo "$templateFilePath not found"
@@ -90,7 +90,7 @@ if [ ! -f "$templateFilePath" ]; then
 fi
 
 #parameter file path
-parametersFilePath="./parameters.json"
+parametersFilePath="../arm/parameters.json"
 
 if [ ! -f "$parametersFilePath" ]; then
 	echo "$parametersFilePath not found"

--- a/twas-nd/README.md
+++ b/twas-nd/README.md
@@ -22,7 +22,7 @@
    mvn -Dgit.repo=<repo_user> -Dgit.tag=<repo_tag> -DibmUserId=<entitledIBMid> -DibmUserPwd=<entitledIBMidPwd> -DvmAdminId=<vmAdminId> -DvmAdminPwd=<vmAdminPwd> -DdnsLabelPrefix=<dnsLabelPrefix> -Dtest.args="-Test All" -Ptemplate-validation-tests -Dtemplate.validation.tests.directory=../../arm-ttk/arm-ttk clean install
    ```
 
-1. Change to `./target/arm` directory
+1. Change to `./target/cli` directory
 1. Using `deploy.azcli` to deploy
 
    ```bash

--- a/twas-nd/pom.xml
+++ b/twas-nd/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>
         <artifactId>azure-javaee-iaas-parent</artifactId>
-        <version>1.0.7</version>
+        <version>1.0.11</version>
         <relativePath></relativePath>
     </parent>
     

--- a/twas-nd/src/main/cli/deploy.azcli
+++ b/twas-nd/src/main/cli/deploy.azcli
@@ -82,7 +82,7 @@ if [ -z "$deploymentName" ] || [ -z "$subscriptionId" ] || [ -z "$resourceGroupN
 fi
 
 #templateFile Path - template file to be used
-templateFilePath="./mainTemplate.json"
+templateFilePath="../arm/mainTemplate.json"
 
 if [ ! -f "$templateFilePath" ]; then
 	echo "$templateFilePath not found"
@@ -90,7 +90,7 @@ if [ ! -f "$templateFilePath" ]; then
 fi
 
 #parameter file path
-parametersFilePath="./parameters.json"
+parametersFilePath="../arm/parameters.json"
 
 if [ ! -f "$parametersFilePath" ]; then
 	echo "$parametersFilePath not found"


### PR DESCRIPTION
With pull request Azure/azure-javaee-iaas#20 is merged, it's time to move utility scripts that're not part of deployment scripts included in the offer to `src/main/cli` for better organization of code structure.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>