### PR TITLE
Add timestamps for entitlement check and WAS installation update

### DIFF
--- a/ihs/pom.xml
+++ b/ihs/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.websphere-ihs.image</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/ihs/src/main/scripts/virtualimage.properties
+++ b/ihs/src/main/scripts/virtualimage.properties
@@ -28,3 +28,7 @@ PLUGIN_INSTALL_DIRECTORY=/datadrive/IBM/WebSphere/Plugins/V9
 WCT_INSTALL_DIRECTORY=/datadrive/IBM/WebSphere/Toolbox/V9
 SSL_PREF="com.ibm.cic.common.core.preferences.ssl.nonsecureMode=false"
 DOWNLOAD_PREF="com.ibm.cic.common.core.preferences.preserveDownloadedArtifacts=false"
+WAS_LOG_PATH=/var/log/cloud-init-was.log
+UNENTITLED=Unentitled
+ENTITLED=Entitled
+UNDEFINED=Undefined

--- a/ihs/src/main/scripts/was-check.sh
+++ b/ihs/src/main/scripts/was-check.sh
@@ -17,15 +17,14 @@
 # Get tWAS installation properties
 source /datadrive/virtualimage.properties
 
-wasLog=/var/log/cloud-init-was.log
-echo "$(date): Start to check entitlement." > $wasLog
+echo "$(date): Start to check entitlement." > $WAS_LOG_PATH
 
 # Read custom data from ovf-env.xml
 customData=`xmllint --xpath "//*[local-name()='Environment']/*[local-name()='ProvisioningSection']/*[local-name()='LinuxProvisioningConfigurationSet']/*[local-name()='CustomData']/text()" /var/lib/waagent/ovf-env.xml`
 read -r -a ibmIdCredentials <<< "$(echo $customData | base64 -d)"
 
 # Check whether IBMid is entitled or not
-result=Unentitled
+result=$UNENTITLED
 if [ ${#ibmIdCredentials[@]} -eq 2 ]; then
     userName=${ibmIdCredentials[0]}
     password=${ibmIdCredentials[1]}
@@ -33,34 +32,34 @@ if [ ${#ibmIdCredentials[@]} -eq 2 ]; then
     ${IM_INSTALL_DIRECTORY}/eclipse/tools/imutilsc saveCredential -secureStorageFile storage_file \
         -userName "$userName" -userPassword "$password" -passportAdvantage
     if [ $? -ne 0 ]; then
-        echo "Cannot connect to Passport Advantage while saving the credential to the secure storage file." >> $wasLog
+        echo "Cannot connect to Passport Advantage while saving the credential to the secure storage file." >> $WAS_LOG_PATH
     fi
     
     output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl listAvailablePackages -cPA -secureStorageFile storage_file)
-    echo $output | grep -q "$WAS_ND_VERSION_ENTITLED" && result=Entitled
-    echo $output | grep -q "$NO_PACKAGES_FOUND" && result=Undefined
+    echo $output | grep -q "$WAS_ND_VERSION_ENTITLED" && result=$ENTITLED
+    echo $output | grep -q "$NO_PACKAGES_FOUND" && result=$UNDEFINED
 else
-    echo "Invalid input format." >> $wasLog
+    echo "Invalid input format." >> $WAS_LOG_PATH
 fi
 
-echo "$(date): Entitlement check completed, start to update WebSphere installation." >> $wasLog
-if [ ${result} = Entitled ]; then
+echo "$(date): Entitlement check completed, start to update WebSphere installation." >> $WAS_LOG_PATH
+if [ ${result} = $ENTITLED ]; then
     # Update all packages for the entitled user
     output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl updateAll -repositories "$REPOSITORY_URL" \
         -acceptLicense -log log_file -installFixes recommended -secureStorageFile storage_file -preferences $SSL_PREF,$DOWNLOAD_PREF -showProgress)
-    echo "$output" >> $wasLog
+    echo "$output" >> $WAS_LOG_PATH
 else
     # Remove installations for the un-entitled or undefined user
     output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl uninstall "$IBM_HTTP_SERVER" "$IBM_JAVA_SDK" -installationDirectory ${IHS_INSTALL_DIRECTORY})
-    echo "$output" >> $wasLog
+    echo "$output" >> $WAS_LOG_PATH
     output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl uninstall "$WEBSPHERE_PLUGIN" "$IBM_JAVA_SDK" -installationDirectory ${PLUGIN_INSTALL_DIRECTORY})
-    echo "$output" >> $wasLog
+    echo "$output" >> $WAS_LOG_PATH
     output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl uninstall "$WEBSPHERE_WCT" "$IBM_JAVA_SDK" -installationDirectory ${WCT_INSTALL_DIRECTORY})
-    echo "$output" >> $wasLog
+    echo "$output" >> $WAS_LOG_PATH
     rm -rf /datadrive/IBM && rm -rf /datadrive/virtualimage.properties
 fi
-echo "$(date): WebSphere installation updated." >> $wasLog
-echo ${result} >> $wasLog
+echo "$(date): WebSphere installation updated." >> $WAS_LOG_PATH
+echo ${result} >> $WAS_LOG_PATH
 
 # Scrub the custom data from files which contain sensitive information
 if grep -q "CustomData" /var/lib/waagent/ovf-env.xml; then

--- a/ihs/src/main/scripts/was-check.sh
+++ b/ihs/src/main/scripts/was-check.sh
@@ -17,7 +17,8 @@
 # Get tWAS installation properties
 source /datadrive/virtualimage.properties
 
-echo "Checking at + $(date)" > /var/log/cloud-init-was.log
+wasLog=/var/log/cloud-init-was.log
+echo "$(date): Start to check entitlement." > $wasLog
 
 # Read custom data from ovf-env.xml
 customData=`xmllint --xpath "//*[local-name()='Environment']/*[local-name()='ProvisioningSection']/*[local-name()='LinuxProvisioningConfigurationSet']/*[local-name()='CustomData']/text()" /var/lib/waagent/ovf-env.xml`
@@ -32,32 +33,34 @@ if [ ${#ibmIdCredentials[@]} -eq 2 ]; then
     ${IM_INSTALL_DIRECTORY}/eclipse/tools/imutilsc saveCredential -secureStorageFile storage_file \
         -userName "$userName" -userPassword "$password" -passportAdvantage
     if [ $? -ne 0 ]; then
-        echo "Cannot connect to Passport Advantage while saving the credential to the secure storage file." >> /var/log/cloud-init-was.log
+        echo "Cannot connect to Passport Advantage while saving the credential to the secure storage file." >> $wasLog
     fi
     
     output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl listAvailablePackages -cPA -secureStorageFile storage_file)
     echo $output | grep -q "$WAS_ND_VERSION_ENTITLED" && result=Entitled
     echo $output | grep -q "$NO_PACKAGES_FOUND" && result=Undefined
 else
-    echo "Invalid input format." >> /var/log/cloud-init-was.log
+    echo "Invalid input format." >> $wasLog
 fi
 
+echo "$(date): Entitlement check completed, start to update WebSphere installation." >> $wasLog
 if [ ${result} = Entitled ]; then
     # Update all packages for the entitled user
     output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl updateAll -repositories "$REPOSITORY_URL" \
         -acceptLicense -log log_file -installFixes recommended -secureStorageFile storage_file -preferences $SSL_PREF,$DOWNLOAD_PREF -showProgress)
-    echo "$output" >> /var/log/cloud-init-was.log
+    echo "$output" >> $wasLog
 else
     # Remove installations for the un-entitled or undefined user
     output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl uninstall "$IBM_HTTP_SERVER" "$IBM_JAVA_SDK" -installationDirectory ${IHS_INSTALL_DIRECTORY})
-    echo "$output" >> /var/log/cloud-init-was.log
+    echo "$output" >> $wasLog
     output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl uninstall "$WEBSPHERE_PLUGIN" "$IBM_JAVA_SDK" -installationDirectory ${PLUGIN_INSTALL_DIRECTORY})
-    echo "$output" >> /var/log/cloud-init-was.log
+    echo "$output" >> $wasLog
     output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl uninstall "$WEBSPHERE_WCT" "$IBM_JAVA_SDK" -installationDirectory ${WCT_INSTALL_DIRECTORY})
-    echo "$output" >> /var/log/cloud-init-was.log
+    echo "$output" >> $wasLog
     rm -rf /datadrive/IBM && rm -rf /datadrive/virtualimage.properties
 fi
-echo ${result} >> /var/log/cloud-init-was.log
+echo "$(date): WebSphere installation updated." >> $wasLog
+echo ${result} >> $wasLog
 
 # Scrub the custom data from files which contain sensitive information
 if grep -q "CustomData" /var/lib/waagent/ovf-env.xml; then

--- a/twas-nd/pom.xml
+++ b/twas-nd/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.websphere-traditional.image</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/twas-nd/src/main/scripts/virtualimage.properties
+++ b/twas-nd/src/main/scripts/virtualimage.properties
@@ -23,3 +23,7 @@ WAS_ND_INSTALL_DIRECTORY=/datadrive/IBM/WebSphere/ND/V9
 IM_SHARED_DIRECTORY=/datadrive/IBM/IMShared
 SSL_PREF="com.ibm.cic.common.core.preferences.ssl.nonsecureMode=false"
 DOWNLOAD_PREF="com.ibm.cic.common.core.preferences.preserveDownloadedArtifacts=false"
+WAS_LOG_PATH=/var/log/cloud-init-was.log
+UNENTITLED=Unentitled
+ENTITLED=Entitled
+UNDEFINED=Undefined

--- a/twas-nd/src/main/scripts/was-check.sh
+++ b/twas-nd/src/main/scripts/was-check.sh
@@ -17,15 +17,14 @@
 # Get tWAS installation properties
 source /datadrive/virtualimage.properties
 
-wasLog=/var/log/cloud-init-was.log
-echo "$(date): Start to check entitlement." > $wasLog
+echo "$(date): Start to check entitlement." > $WAS_LOG_PATH
 
 # Read custom data from ovf-env.xml
 customData=`xmllint --xpath "//*[local-name()='Environment']/*[local-name()='ProvisioningSection']/*[local-name()='LinuxProvisioningConfigurationSet']/*[local-name()='CustomData']/text()" /var/lib/waagent/ovf-env.xml`
 read -r -a ibmIdCredentials <<< "$(echo $customData | base64 -d)"
 
 # Check whether IBMid is entitled or not
-result=Unentitled
+result=$UNENTITLED
 if [ ${#ibmIdCredentials[@]} -eq 2 ]; then
     userName=${ibmIdCredentials[0]}
     password=${ibmIdCredentials[1]}
@@ -33,30 +32,30 @@ if [ ${#ibmIdCredentials[@]} -eq 2 ]; then
     ${IM_INSTALL_DIRECTORY}/eclipse/tools/imutilsc saveCredential -secureStorageFile storage_file \
         -userName "$userName" -userPassword "$password" -passportAdvantage
     if [ $? -ne 0 ]; then
-        echo "Cannot connect to Passport Advantage while saving the credential to the secure storage file." >> $wasLog
+        echo "Cannot connect to Passport Advantage while saving the credential to the secure storage file." >> $WAS_LOG_PATH
     fi
     
     output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl listAvailablePackages -cPA -secureStorageFile storage_file)
-    echo $output | grep -q "$WAS_ND_VERSION_ENTITLED" && result=Entitled
-    echo $output | grep -q "$NO_PACKAGES_FOUND" && result=Undefined
+    echo $output | grep -q "$WAS_ND_VERSION_ENTITLED" && result=$ENTITLED
+    echo $output | grep -q "$NO_PACKAGES_FOUND" && result=$UNDEFINED
 else
-    echo "Invalid input format." >> $wasLog
+    echo "Invalid input format." >> $WAS_LOG_PATH
 fi
 
-echo "$(date): Entitlement check completed, start to update WebSphere installation." >> $wasLog
-if [ ${result} = Entitled ]; then
+echo "$(date): Entitlement check completed, start to update WebSphere installation." >> $WAS_LOG_PATH
+if [ ${result} = $ENTITLED ]; then
     # Update all packages for the entitled user
     output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl updateAll -repositories "$REPOSITORY_URL" \
         -acceptLicense -log log_file -installFixes recommended -secureStorageFile storage_file -preferences $SSL_PREF,$DOWNLOAD_PREF -showProgress)
-    echo "$output" >> $wasLog
+    echo "$output" >> $WAS_LOG_PATH
 else
     # Remove tWAS installation for the un-entitled or undefined user
     output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl uninstall "$WAS_ND_TRADITIONAL" "$IBM_JAVA_SDK" -installationDirectory ${WAS_ND_INSTALL_DIRECTORY})
-    echo "$output" >> $wasLog
+    echo "$output" >> $WAS_LOG_PATH
     rm -rf /datadrive/IBM && rm -rf /datadrive/virtualimage.properties
 fi
-echo "$(date): WebSphere installation updated." >> $wasLog
-echo ${result} >> $wasLog
+echo "$(date): WebSphere installation updated." >> $WAS_LOG_PATH
+echo ${result} >> $WAS_LOG_PATH
 
 # Scrub the custom data from files which contain sensitive information
 if grep -q "CustomData" /var/lib/waagent/ovf-env.xml; then


### PR DESCRIPTION
## Description

This is the 1st PR to address WASdev/azure.websphere-traditional.cluster/issues/105.
The 2nd PR opened in cluster repo is https://github.com/WASdev/azure.websphere-traditional.cluster/pull/106.

## Change summary

* Add timestamps for entitlement check and was update
* Move hard-coded values to properties file

## Testing

See section **Testing** from [the 2nd PR](https://github.com/WASdev/azure.websphere-traditional.cluster/pull/106) mentioned above.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>