### PR TITLE
Use an appropriate size for data disk in the base images

### DIFF
--- a/config.properties
+++ b/config.properties
@@ -17,5 +17,7 @@ image.offer=RHEL
 image.sku=8_4
 image.version=latest
 
+datadisk.sizeGB=25
+
 azure.apiVersion=2020-06-01
 azure.apiVersion2=2019-06-01

--- a/ihs/src/main/arm/mainTemplate.json
+++ b/ihs/src/main/arm/mainTemplate.json
@@ -238,7 +238,7 @@ sudo mkdir /datadrive && sudo mount /dev/${disk}1 /datadrive",
                     "dataDisks": [
                         {
                             "name": "datadisk1",
-                            "diskSizeGB": 900,
+                            "diskSizeGB": "[int('${datadisk.sizeGB}')]",
                             "lun": 0,
                             "vhd": {
                                 "uri": "[concat(reference(variables('name_storageAccount')).primaryEndpoints.blob, 'vhds/', variables('name_virtualMachine'), 'datadisk1.vhd')]"

--- a/twas-nd/src/main/arm/mainTemplate.json
+++ b/twas-nd/src/main/arm/mainTemplate.json
@@ -238,7 +238,7 @@ sudo mkdir /datadrive && sudo mount /dev/${disk}1 /datadrive",
                     "dataDisks": [
                         {
                             "name": "datadisk1",
-                            "diskSizeGB": 900,
+                            "diskSizeGB": "[int('${datadisk.sizeGB}')]",
                             "lun": 0,
                             "vhd": {
                                 "uri": "[concat(reference(variables('name_storageAccount')).primaryEndpoints.blob, 'vhds/', variables('name_virtualMachine'), 'datadisk1.vhd')]"


### PR DESCRIPTION
## Description

This PR is to resolve the following issues:
* Fix WASdev/azure.websphere-traditional.cluster/issues/109

## Change summary

* Add new property `datadisk.sizeGB`
* Reference data disk size from config file

## Testing

The following test cases have been passed before opening the above two PRs:
* Successfully created twas-nd and ihs private VM images based on image repo;
* Successfully created a tWAS cluster (1 dmgr, 1 worker node & 1 IHS) by referencing the private images with an entitled IBMid. 
  * User can then successfully deploy a default application `DefaultApplication` to the cluster and IHS, which is accessible later;
* Created an empty tWAS cluster (1 dmgr, 1 worker node & 1 IHS) by referencing the private images with an invalid IBMid.
   * SSH into VMs and verified that WAS installation is removed from all VMs
* Verified that the size of data disk attached to each VM is 25G; 
* SSH into VMs and verified that the total size of data disk mounted to `/datadrive` is 25G by running `df -h`:
  ```
  twas-nd:
  Filesystem                 Size  Used Avail Use% Mounted on
  /dev/sdc1                   25G  211M   25G   1% /datadrive	<= invalid IBM ID
  /dev/sdc1                   25G  2.2G   23G   9% /datadrive     <= valid IBM ID

  ihs:
  Filesystem                 Size  Used Avail Use% Mounted on
  /dev/sdc1                   25G  211M   25G   1% /datadrive	<= invalid IBM ID
  /dev/sdc1                   25G  1.5G   24G   6% /datadrive     <= valid IBM ID
  ``` 

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>