### PR TITLE
ARM template to deploy a VM installed with tWAS base edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # [Deploy an Azure VM with RHEL 8.4, IBM HTTP Server V9.0 & IBM JDK 8.0 pre-installed](/ihs)
+# [Deploy an Azure VM with RHEL 8.4, IBM WebSphere Application Server Traditional V9.0.5 & IBM JDK 8.0 pre-installed](/twas-base)
 # [Deploy an Azure VM with RHEL 8.4, IBM WebSphere Application Server ND Traditional V9.0.5 & IBM JDK 8.0 pre-installed](/twas-nd)
 # [Related: Deploy RHEL 8.4 VMs on Azure with IBM WebSphere Application Server ND Traditional V9.0.5 cluster pre-installed](https://github.com/WASdev/azure.websphere-traditional.cluster)
 # [Issues](https://github.com/WASdev/azure.websphere-traditional.cluster/issues)

--- a/twas-base/README.md
+++ b/twas-base/README.md
@@ -1,0 +1,58 @@
+# Deploy an Azure VM with RHEL 8.4, IBM WebSphere Application Server Traditional V9.0.5 & IBM JDK 8.0 pre-installed
+
+## Prerequisites
+
+1. Register an [Azure subscription](https://azure.microsoft.com/).
+1. Register an [IBM id](https://www.ibm.com/account/reg/sg-en/signup?formid=urx-19776). Contact IBM to make it entitled.
+1. Install [Azure CLI](https://docs.microsoft.com/cli/azure/install-azure-cli?view=azure-cli-latest).
+1. Install [PowerShell Core](https://docs.microsoft.com/powershell/scripting/install/installing-powershell-core-on-linux?view=powershell-7.1).
+1. Install [Maven](https://maven.apache.org/download.cgi).
+1. Install [`jq`](https://stedolan.github.io/jq/download/).
+
+## Steps of deployment
+
+1. Checkout [azure-javaee-iaas](https://github.com/Azure/azure-javaee-iaas)
+   1. Change to directory hosting the repo project & run `mvn clean install`
+1. Checkout [arm-ttk](https://github.com/Azure/arm-ttk) under the specified parent directory
+1. Checkout this repo under the same parent directory and change to directory hosting the repo project
+1. Change to sub-directory `twas-base`
+1. Build the project by replacing all placeholder `${<place_holder>}` with valid values
+
+   ```bash
+   mvn -Dgit.repo=<repo_user> -Dgit.tag=<repo_tag> -DibmUserId=<entitledIBMid> -DibmUserPwd=<entitledIBMidPwd> -DvmAdminId=<vmAdminId> -DvmAdminPwd=<vmAdminPwd> -DdnsLabelPrefix=<dnsLabelPrefix> -Dtest.args="-Test All" -Ptemplate-validation-tests -Dtemplate.validation.tests.directory=../../arm-ttk/arm-ttk clean install
+   ```
+
+1. Change to `./target/cli` directory
+1. Using `deploy.azcli` to deploy
+
+   ```bash
+   ./deploy.azcli -n <deploymentName> -i <subscriptionId> -g <resourceGroupName> -l <resourceGroupLocation>
+   ```
+
+## After deployment
+
+1. You can [capture the source VM to a custom image](https://docs.microsoft.com/azure/virtual-machines/linux/capture-image), which consists of RHEL 8.4, IBM WebSphere Application Server Traditional V9.0.5 & IBM JDK 8.0, so it can be reused to create VM instances based on it using the same subscription;
+1. Similar to creating a custom private image, you can also [create a Virtual Machine offer in Azure Marketplace](https://docs.microsoft.com/azure/marketplace/cloud-partner-portal/virtual-machine/cpp-virtual-machine-offer), which is globally public and accessible. You can see more information in the following section.
+
+### Creating Virtual Machine offer in Azure Marketplace manually
+
+1. Deploy an Azure VM provisioned with RHEL, WebSphere & JDK (e.g., RHEL 8.4, IBM WebSphere Application Server Traditional V9.0.5 & IBM JDK 8.0). Use different combinations of OS, WebSphere and JDK per your requirements. If you want to install WebSphere and JDK in a separate data disk, only provision the VM with RHEL. Manual deployment or using the tailored ARM template works.
+   1. Use un-managed disks instead of managed disks for VM provision. By doing so, the VHDs attached to the VM are stored in the storage account, which can be accessed later during the certification process of publishing VM image into Azure Marketplace
+   1. This repo is an example on how to create an un-managed OS disk and data disk in the storage account using ARM template;
+1. [Generate VM image](https://docs.microsoft.com/azure/virtual-machines/linux/capture-image):
+   1. SSH into the provisioned VM
+      1. Delete all sensitive files that you don't want them appear in image
+      1. Update applications installed on the system: `sudo yum update -y`
+      1. Deprovision: `sudo waagent -deprovision+user -force`
+      1. exit
+   1. De-allocate VM: `az vm deallocate --resource-group <resourceGroupName> --name <vmName>`
+   1. Generalize VM: `az vm generalize --resource-group <resourceGroupName> --name <vmName>`
+   1. [**Optional**] To test if the VHD of de-allocated and generalized VM works, you can create image and use it for creating new VM instances to verify
+      1. `az image create --resource-group <resourceGroupName> --name <imageName> --source <vmName>`
+      1. `az vm create --resource-group <resourceGroupName> --name <newVMInstanceName> --image <imageId> --generate-ssh-keys`
+1. Create virtual machine offer on Azure Marketplace using the VM image:
+   1. [How to plan a virtual machine offer](https://docs.microsoft.com/azure/marketplace/marketplace-virtual-machines)
+   1. [How to create plans for a virtual machine offer](https://docs.microsoft.com/azure/marketplace/azure-vm-create-plans)
+   1. [How to create a virtual machine using your own image](https://docs.microsoft.com/azure/marketplace/azure-vm-create-using-own-image)
+   1. [How to generate a SAS URI for a VM image](https://docs.microsoft.com/azure/marketplace/azure-vm-get-sas-uri)
+1. Once the VM offer created successfully in Azure Marketplace, try to deploy a virtual machine using this VM offer and export the ARM template, where you can find how to correctly reference the VM offer in the upstream ARM template.

--- a/twas-base/pom.xml
+++ b/twas-base/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>
         <artifactId>azure-javaee-iaas-parent</artifactId>
-        <version>1.0.11</version>
+        <version>1.0.13</version>
         <relativePath></relativePath>
     </parent>
     
@@ -33,13 +33,13 @@
     <name>${project.artifactId}</name>
 
     <properties>
-        <git.proj>azure.websphere-traditional.image</git.proj>
         <git.repo>WASdev</git.repo>
         <!-- 
-            The default value for `git.tag` is defined in parent pom "azure-javaee-iaas-parent", which is `master`.
+            The default value for `git.tag` is defined in parent pom "azure-javaee-iaas-parent", which is `main`.
             It can also be overridden with `-Dgit.tag` at the maven command line if you use a different git branch.
             See https://github.com/Azure/azure-javaee-iaas/blob/main/arm-parent/pom.xml#L22-L24 for more available properties.
          -->
-        <template.pid.properties.url>${artifactsLocationBase}/${git.proj}/${git.tag}/config.properties</template.pid.properties.url>
+        <artifactsLocationBase>https://raw.githubusercontent.com/${git.repo}/azure.websphere-traditional.image/${git.tag}</artifactsLocationBase>
+        <template.pid.properties.url>${artifactsLocationBase}/config.properties</template.pid.properties.url>
     </properties>
 </project>

--- a/twas-base/pom.xml
+++ b/twas-base/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+     Copyright (c) Microsoft Corporation.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.ibm.websphere.azure</groupId>
+    <artifactId>azure.websphere-base.image</artifactId>
+    <version>1.0.0</version>
+    
+    <parent>
+        <groupId>com.microsoft.azure.iaas</groupId>
+        <artifactId>azure-javaee-iaas-parent</artifactId>
+        <version>1.0.11</version>
+        <relativePath></relativePath>
+    </parent>
+    
+    <packaging>jar</packaging>
+    <name>${project.artifactId}</name>
+
+    <properties>
+        <git.proj>azure.websphere-traditional.image</git.proj>
+        <git.repo>WASdev</git.repo>
+        <!-- 
+            The default value for `git.tag` is defined in parent pom "azure-javaee-iaas-parent", which is `master`.
+            It can also be overridden with `-Dgit.tag` at the maven command line if you use a different git branch.
+            See https://github.com/Azure/azure-javaee-iaas/blob/main/arm-parent/pom.xml#L22-L24 for more available properties.
+         -->
+        <template.pid.properties.url>${artifactsLocationBase}/${git.proj}/${git.tag}/config.properties</template.pid.properties.url>
+    </properties>
+</project>

--- a/twas-base/src/main/arm/mainTemplate.json
+++ b/twas-base/src/main/arm/mainTemplate.json
@@ -1,0 +1,289 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "_artifactsLocation": {
+            "type": "string",
+            "defaultValue": "[deployment().properties.templateLink.uri]"
+        },
+        "_artifactsLocationSasToken": {
+            "type": "securestring",
+            "defaultValue": ""
+        },
+        "location": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().location]"
+        },
+        "dnsLabelPrefix": {
+            "type": "string"
+        },
+        "vmSize": {
+            "defaultValue": "Standard_D2_v3",
+            "type": "string"
+        },
+        "osDiskType": {
+            "defaultValue": "Standard_LRS",
+            "type": "string"
+        },
+        "addressPrefix": {
+            "defaultValue": "10.0.0.0/16",
+            "type": "string"
+        },
+        "subnetName": {
+            "defaultValue": "subnet01",
+            "type": "string"
+        },
+        "subnetAddressPrefix": {
+            "defaultValue": "10.0.1.0/24",
+            "type": "string"
+        },
+        "storageAccount": {
+            "defaultValue": "",
+            "type": "string"
+        },
+        "ibmUserId": {
+            "type": "string"
+        },
+        "ibmUserPwd": {
+            "type": "securestring"
+        },        
+        "vmName": {
+            "defaultValue": "",
+            "type": "string"
+        },
+        "vmAdminId": {
+            "type": "string"
+        },
+        "vmAdminPwd": {
+            "type": "securestring"
+        },
+        "guidValue": {
+            "defaultValue": "[newGuid()]",
+            "type": "string"
+        }
+    },
+    "variables": {
+        "const_arguments": "[concat(' -u ',parameters('ibmUserId'),' -p ',parameters('ibmUserPwd'))]",
+        "const_cloudInitScript": "#!/bin/bash
+disk=sda
+sudo parted /dev/${disk} --script mklabel gpt mkpart xfspart xfs 0% 100%
+if [ $? -ne 0 ]; then
+    disk=sdb
+    sudo parted /dev/${disk} --script mklabel gpt mkpart xfspart xfs 0% 100%
+    if [ $? -ne 0 ]; then
+        disk=sdc
+        sudo parted /dev/${disk} --script mklabel gpt mkpart xfspart xfs 0% 100%
+    fi
+fi
+sudo mkfs.xfs /dev/${disk}1
+sudo partprobe /dev/${disk}1
+sudo mkdir /datadrive && sudo mount /dev/${disk}1 /datadrive",
+        "const_dnsLabelPrefix": "[concat(parameters('dnsLabelPrefix'), take(replace(parameters('guidValue'),'-',''),6))]",
+        "const_scriptLocation": "[uri(parameters('_artifactsLocation'), 'scripts/')]",
+        "name_networkInterface": "[concat(variables('name_virtualMachine'), '-if')]",
+        "name_networkSecurityGroup": "[concat(variables('const_dnsLabelPrefix'), '-nsg')]",
+        "name_publicIPAddress": "[concat(variables('name_virtualMachine'), '-ip')]",
+        "name_storageAccount": "[if(empty(parameters('storageAccount')), concat('storage',take(replace(parameters('guidValue'),'-',''),6)), parameters('storageAccount'))]",
+        "name_virtualMachine": "[if(empty(parameters('vmName')) ,concat('wasVM', take(replace(parameters('guidValue'),'-',''),6)), parameters('vmName'))]",
+        "name_virtualNetwork": "[concat(variables('const_dnsLabelPrefix'), '-vnet')]",
+        "ref_networkInterface": "[resourceId('Microsoft.Network/networkInterfaces', variables('name_networkInterface'))]",
+        "ref_networkSecurityGroup": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('name_networkSecurityGroup'))]",
+        "ref_publicIPAddress": "[resourceId('Microsoft.Network/publicIPAddresses', variables('name_publicIPAddress'))]",
+        "ref_storage": "[resourceId('Microsoft.Storage/storageAccounts', variables('name_storageAccount'))]",
+        "ref_subnet": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('name_virtualNetwork'), parameters('subnetName'))]",
+        "ref_virtualMachine": "[resourceId('Microsoft.Compute/virtualMachines', variables('name_virtualMachine'))]",
+        "ref_virtualNetwork": "[resourceId('Microsoft.Network/virtualNetworks', variables('name_virtualNetwork'))]"
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Network/networkSecurityGroups",
+            "apiVersion": "${azure.apiVersion}",
+            "name": "[variables('name_networkSecurityGroup')]",
+            "location": "[parameters('location')]",
+            "properties": {
+                "securityRules": [
+                    {
+                        "name": "TCP",
+                        "properties": {
+                            "protocol": "TCP",
+                            "sourcePortRange": "*",
+                            "sourceAddressPrefix": "*",
+                            "destinationAddressPrefix": "*",
+                            "access": "Allow",
+                            "priority": 320,
+                            "direction": "Inbound",
+                            "destinationPortRanges": [
+                                "22"
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Microsoft.Network/virtualNetworks",
+            "apiVersion": "${azure.apiVersion}",
+            "name": "[variables('name_virtualNetwork')]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[variables('ref_networkSecurityGroup')]"
+            ],
+            "properties": {
+                "addressSpace": {
+                    "addressPrefixes": [
+                        "[parameters('addressPrefix')]"
+                    ]
+                },
+                "enableDdosProtection": false,
+                "enableVmProtection": false
+            }
+        },
+        {
+            "type": "Microsoft.Network/virtualNetworks/subnets",
+            "apiVersion": "${azure.apiVersion}",
+            "name": "[concat(variables('name_virtualNetwork'), '/', parameters('subnetName'))]",
+            "dependsOn": [
+                "[variables('ref_virtualNetwork')]",
+                "[variables('ref_networkSecurityGroup')]"
+            ],
+            "properties": {
+                "addressPrefix": "[parameters('subnetAddressPrefix')]",
+                "networkSecurityGroup": {
+                    "id": "[variables('ref_networkSecurityGroup')]"
+                }
+            }
+        },                
+        {
+            "type": "Microsoft.Network/publicIPAddresses",
+            "apiVersion": "${azure.apiVersion}",
+            "name": "[variables('name_publicIPAddress')]",
+            "location": "[parameters('location')]",
+            "properties": {
+                "publicIPAllocationMethod": "Dynamic",
+                "dnsSettings": {
+                    "domainNameLabel": "[variables('const_dnsLabelPrefix')]"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Network/networkInterfaces",
+            "apiVersion": "${azure.apiVersion}",
+            "name": "[variables('name_networkInterface')]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[variables('ref_publicIPAddress')]",
+                "[variables('ref_subnet')]"
+            ],
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "name": "ipconfig1",
+                        "properties": {
+                            "privateIPAllocationMethod": "Dynamic",
+                            "publicIPAddress": {
+                                "id": "[variables('ref_publicIPAddress')]"
+                            },
+                            "subnet": {
+                                "id": "[variables('ref_subnet')]"
+                            }
+                        }
+                    }
+                ],
+                "enableAcceleratedNetworking": false,
+                "enableIPForwarding": false,
+                "primary": true
+            }
+        },
+        {
+            "name": "[variables('name_storageAccount')]",
+            "type": "Microsoft.Storage/storageAccounts",
+            "apiVersion": "${azure.apiVersion2}",
+            "location": "[parameters('location')]",
+            "properties": {},
+            "kind": "Storage",
+            "sku": {
+                "name": "[parameters('osDiskType')]"
+            }
+        },
+        {
+            "type": "Microsoft.Compute/virtualMachines",
+            "apiVersion": "${azure.apiVersion}",
+            "name": "[variables('name_virtualMachine')]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[variables('ref_networkInterface')]",
+                "[variables('ref_storage')]"
+            ],
+            "tags": {
+                "SkipGreenTeamLinuxSSHAuthForResource": true
+            },
+            "properties": {
+                "hardwareProfile": {
+                    "vmSize": "[parameters('vmSize')]"
+                },
+                "storageProfile": {
+                    "imageReference": {
+                        "publisher": "${image.publisher}",
+                        "offer": "${image.offer}",
+                        "sku": "${image.sku}",
+                        "version": "${image.version}"
+                    },
+                    "osDisk": {
+                        "name": "[concat(variables('name_virtualMachine'), '-disk')]",
+                        "createOption": "FromImage",
+                        "vhd": {
+                            "uri": "[concat(reference(variables('name_storageAccount')).primaryEndpoints.blob, 'vhds/', variables('name_virtualMachine'), '.vhd')]"
+                        }
+                    },
+                    "dataDisks": [
+                        {
+                            "name": "datadisk1",
+                            "diskSizeGB": "[int('${datadisk.sizeGB}')]",
+                            "lun": 0,
+                            "vhd": {
+                                "uri": "[concat(reference(variables('name_storageAccount')).primaryEndpoints.blob, 'vhds/', variables('name_virtualMachine'), 'datadisk1.vhd')]"
+                            },
+                            "createOption": "Empty"
+                        }
+                    ]
+                },
+                "osProfile": {
+                    "computerName": "[variables('name_virtualMachine')]",
+                    "adminUsername": "[parameters('vmAdminId')]",
+                    "adminPassword": "[parameters('vmAdminPwd')]",
+                    "customData": "[base64(variables('const_cloudInitScript'))]"
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "id": "[variables('ref_networkInterface')]"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "apiVersion": "${azure.apiVersion}",
+            "name": "[concat(variables('name_virtualMachine'), '/CustomScript')]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[variables('ref_virtualMachine')]"
+            ],
+            "properties": {
+                "autoUpgradeMinorVersion": true,
+                "publisher": "Microsoft.Azure.Extensions",
+                "type": "CustomScript",
+                "typeHandlerVersion": "2.0",
+                "settings": {
+                    "fileUris": [
+                        "[uri(variables('const_scriptLocation'), concat('install.sh', parameters('_artifactsLocationSasToken')))]",
+                        "[uri(variables('const_scriptLocation'), concat('was-check.sh', parameters('_artifactsLocationSasToken')))]",
+                        "[uri(variables('const_scriptLocation'), concat('virtualimage.properties', parameters('_artifactsLocationSasToken')))]"
+                    ],
+                    "commandToExecute": "[concat('sh install.sh', variables('const_arguments'))]"
+                }
+            }
+        }
+    ]
+}

--- a/twas-base/src/main/arm/parameters.json
+++ b/twas-base/src/main/arm/parameters.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "_artifactsLocation": {
+            "value": "${artifactsLocationBase}/${git.proj}/${git.tag}/twas-base/src/main/"
+        },
+        "dnsLabelPrefix":{
+            "value": "${dnsLabelPrefix}"
+        },
+        "ibmUserId": {
+            "value": "${ibmUserId}"
+        },
+        "ibmUserPwd": {
+            "value": "${ibmUserPwd}"
+        },
+        "vmAdminId": {
+            "value": "${vmAdminId}"
+        },
+        "vmAdminPwd": {
+            "value": "${vmAdminPwd}"
+        }
+    }
+}

--- a/twas-base/src/main/arm/parameters.json
+++ b/twas-base/src/main/arm/parameters.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "_artifactsLocation": {
-            "value": "${artifactsLocationBase}/${git.proj}/${git.tag}/twas-base/src/main/"
+            "value": "${artifactsLocationBase}/twas-base/src/main/"
         },
         "dnsLabelPrefix":{
             "value": "${dnsLabelPrefix}"

--- a/twas-base/src/main/cli/deploy.azcli
+++ b/twas-base/src/main/cli/deploy.azcli
@@ -1,0 +1,142 @@
+#!/bin/bash
+
+#      Copyright (c) Microsoft Corporation.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+# 
+#           http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+set -euo pipefail
+IFS=$'\n\t'
+
+# -e: immediately exit if any command has a non-zero exit status
+# -o: prevents errors in a pipeline from being masked
+# IFS new value is less likely to cause confusing bugs when looping arrays or arguments (e.g. $@)
+
+usage() { echo "Usage: $0 -n <deploymentName> -i <subscriptionId> -g <resourceGroupName> -l <resourceGroupLocation>" 1>&2; exit 1; }
+
+declare deploymentName=""
+declare subscriptionId=""
+declare resourceGroupName=""
+declare resourceGroupLocation=""
+
+# Initialize parameters specified from command line
+while getopts ":n:f:i:g:l:" arg; do
+	case "${arg}" in
+		n)
+			deploymentName=${OPTARG}
+			;;
+		i)
+			subscriptionId=${OPTARG}
+			;;
+		g)
+			resourceGroupName=${OPTARG}
+			;;
+		l)
+			resourceGroupLocation=${OPTARG}
+			;;
+		esac
+done
+shift $((OPTIND-1))
+
+#Prompt for parameters is some required parameters are missing
+if [[ -z "$deploymentName" ]]; then
+	echo "Enter a name for this deployment:"
+	read deploymentName
+fi
+
+if [[ -z "$subscriptionId" ]]; then
+	echo "Your subscription ID can be looked up with the CLI using: az account show --out json "
+	echo "Enter your subscription ID:"
+	read subscriptionId
+	[[ "${subscriptionId:?}" ]]
+fi
+
+if [[ -z "$resourceGroupName" ]]; then
+	echo "This script will look for an existing resource group, otherwise a new one will be created "
+	echo "You can create new resource groups with the CLI using: az group create "
+	echo "Enter a resource group name:"
+	read resourceGroupName
+	[[ "${resourceGroupName:?}" ]]
+fi
+
+if [[ -z "$resourceGroupLocation" ]]; then
+	echo "If creating a *new* resource group, you need to set a location "
+	echo "You can lookup locations with the CLI using: az account list-locations "
+	
+	echo "Enter resource group location:"
+	read resourceGroupLocation
+fi
+
+if [ -z "$deploymentName" ] || [ -z "$subscriptionId" ] || [ -z "$resourceGroupName" ]; then
+	echo "Either one of deploymentName, subscriptionId and resourceGroupName is empty"
+	usage
+fi
+
+#templateFile Path - template file to be used
+templateFilePath="../arm/mainTemplate.json"
+
+if [ ! -f "$templateFilePath" ]; then
+	echo "$templateFilePath not found"
+	exit 1
+fi
+
+#parameter file path
+parametersFilePath="../arm/parameters.json"
+
+if [ ! -f "$parametersFilePath" ]; then
+	echo "$parametersFilePath not found"
+	exit 1
+fi
+
+#login to azure using your credentials
+az account show 1> /dev/null
+
+if [ $? != 0 ]; then
+	az login
+fi
+
+#set the default subscription id
+az account set --subscription $subscriptionId
+
+set +e
+
+#Check for existing RG
+az group show --name $resourceGroupName 1> /dev/null
+
+if [ $? != 0 ]; then
+	echo "Resource group with name" $resourceGroupName "could not be found. Creating new resource group..."
+	set -e
+	(
+		set -x
+		az group create --name $resourceGroupName --location $resourceGroupLocation 1> /dev/null
+	)
+else
+	echo "Using existing resource group..."
+fi
+resourceGroupLocation=$( az group show --name $resourceGroupName | jq -r '.location' )
+
+set +u
+
+#parameters JSON
+parametersJson=$( cat $parametersFilePath | jq '.parameters' )
+parametersJson=$( echo "$parametersJson" | jq -c '.' )
+
+#Start deployment
+echo "Starting deployment..."
+(
+	az deployment group create --name "$deploymentName" --resource-group "$resourceGroupName" \
+		--template-file "$templateFilePath" --parameters "$parametersJson"
+)
+
+if [[ $? -eq 0 ]]; then
+	echo "Template has been successfully deployed"
+fi

--- a/twas-base/src/main/scripts/install.sh
+++ b/twas-base/src/main/scripts/install.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+
+#      Copyright (c) Microsoft Corporation.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+# 
+#           http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+while getopts "u:p:" opt; do
+    case $opt in
+        u)
+            userName=$OPTARG #IBM user id for downloading artifacts from IBM web site
+        ;;
+        p)
+            password=$OPTARG #password of IBM user id for downloading artifacts from IBM web site
+        ;;
+    esac
+done
+
+# Wait untile the data disk is partitioned and mounted
+output=$(df -h)
+while echo $output | grep -qv "/datadrive"
+do
+    sleep 10
+    echo "Waiting for data disk partition & moute complete..."
+    output=$(df -h)
+done
+name=$(df -h | grep "/datadrive" | awk '{print $1;}' | grep -Po "(?<=\/dev\/).*")
+echo "UUID=$(blkid | grep -Po "(?<=\/dev\/${name}\: UUID=\")[^\"]*(?=\".*)")   /datadrive   xfs   defaults,nofail   1   2" >> /etc/fstab
+
+# Move tWAS entitlement check and application patch script to /var/lib/cloud/scripts/per-instance
+mv was-check.sh /var/lib/cloud/scripts/per-instance
+
+# Move tWAS installation properties file to /datadrive
+mv virtualimage.properties /datadrive
+
+# Get tWAS installation properties
+source /datadrive/virtualimage.properties
+
+# Create installation directories
+mkdir -p ${IM_INSTALL_DIRECTORY} && mkdir -p ${WAS_BASE_INSTALL_DIRECTORY} && mkdir -p ${IM_SHARED_DIRECTORY}
+
+# Install IBM Installation Manager
+wget -O "$IM_INSTALL_KIT" "$IM_INSTALL_KIT_URL" -q
+mkdir im_installer
+unzip -q "$IM_INSTALL_KIT" -d im_installer
+./im_installer/userinstc -log log_file -acceptLicense -installationDirectory ${IM_INSTALL_DIRECTORY}
+
+# Save credentials to a secure storage file
+${IM_INSTALL_DIRECTORY}/eclipse/tools/imutilsc saveCredential -secureStorageFile storage_file \
+    -userName "$userName" -userPassword "$password" -passportAdvantage
+
+# Check whether IBMid is entitled or not
+if [ $? -eq 0 ]; then
+    output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl listAvailablePackages -cPA -secureStorageFile storage_file)
+    if echo "$output" | grep "$WAS_ND_VERSION_ENTITLED"; then
+        echo "IBM account entitlement check succeed."
+    elif echo "$output" | grep "$NO_PACKAGES_FOUND"; then
+        echo "IBM account entitlement check is not available."
+        rm -rf storage_file && rm -rf log_file
+        exit 1
+    else
+        echo "IBM account entitlement check failed."
+        rm -rf storage_file && rm -rf log_file
+        exit 1
+    fi
+else
+    echo "Cannot connect to Passport Advantage."
+    rm -rf storage_file && rm -rf log_file
+    exit 1
+fi
+
+# Install IBM WebSphere Application Server V9 using IBM Instalation Manager
+${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl install "$WAS_BASE_TRADITIONAL" "$IBM_JAVA_SDK" -repositories "$REPOSITORY_URL" \
+    -installationDirectory ${WAS_BASE_INSTALL_DIRECTORY}/ -sharedResourcesDirectory ${IM_SHARED_DIRECTORY}/ \
+    -secureStorageFile storage_file -acceptLicense -preferences $SSL_PREF,$DOWNLOAD_PREF -showProgress
+
+# Remove temporary files
+rm -rf storage_file && rm -rf log_file

--- a/twas-base/src/main/scripts/install.sh
+++ b/twas-base/src/main/scripts/install.sh
@@ -62,7 +62,7 @@ ${IM_INSTALL_DIRECTORY}/eclipse/tools/imutilsc saveCredential -secureStorageFile
 # Check whether IBMid is entitled or not
 if [ $? -eq 0 ]; then
     output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl listAvailablePackages -cPA -secureStorageFile storage_file)
-    if echo "$output" | grep "$WAS_ND_VERSION_ENTITLED"; then
+    if echo "$output" | grep "$WAS_BASE_VERSION_ENTITLED"; then
         echo "IBM account entitlement check succeed."
     elif echo "$output" | grep "$NO_PACKAGES_FOUND"; then
         echo "IBM account entitlement check is not available."

--- a/twas-base/src/main/scripts/install.sh
+++ b/twas-base/src/main/scripts/install.sh
@@ -52,6 +52,7 @@ mkdir -p ${IM_INSTALL_DIRECTORY} && mkdir -p ${WAS_BASE_INSTALL_DIRECTORY} && mk
 wget -O "$IM_INSTALL_KIT" "$IM_INSTALL_KIT_URL" -q
 mkdir im_installer
 unzip -q "$IM_INSTALL_KIT" -d im_installer
+chmod -R 755 ./im_installer/*
 ./im_installer/userinstc -log log_file -acceptLicense -installationDirectory ${IM_INSTALL_DIRECTORY}
 
 # Save credentials to a secure storage file

--- a/twas-base/src/main/scripts/virtualimage.properties
+++ b/twas-base/src/main/scripts/virtualimage.properties
@@ -14,7 +14,7 @@
 WAS_BASE_TRADITIONAL=com.ibm.websphere.BASE.v90
 IBM_JAVA_SDK=com.ibm.java.jdk.v8
 REPOSITORY_URL=https://www.ibm.com/software/repositorymanager/entitled
-WAS_ND_VERSION_ENTITLED=ND.v90_9.0.5007
+WAS_BASE_VERSION_ENTITLED=BASE.v90_9.0.5009
 NO_PACKAGES_FOUND="No packages were found"
 IM_INSTALL_KIT=agent.installer.linux.gtk.x86_64.zip
 IM_INSTALL_KIT_URL=https://public.dhe.ibm.com/ibmdl/export/pub/software/im/zips/${IM_INSTALL_KIT}

--- a/twas-base/src/main/scripts/virtualimage.properties
+++ b/twas-base/src/main/scripts/virtualimage.properties
@@ -1,0 +1,29 @@
+#      Copyright (c) Microsoft Corporation.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+# 
+#           http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+WAS_BASE_TRADITIONAL=com.ibm.websphere.BASE.v90
+IBM_JAVA_SDK=com.ibm.java.jdk.v8
+REPOSITORY_URL=https://www.ibm.com/software/repositorymanager/entitled
+WAS_ND_VERSION_ENTITLED=ND.v90_9.0.5007
+NO_PACKAGES_FOUND="No packages were found"
+IM_INSTALL_KIT=agent.installer.linux.gtk.x86_64.zip
+IM_INSTALL_KIT_URL=https://public.dhe.ibm.com/ibmdl/export/pub/software/im/zips/${IM_INSTALL_KIT}
+IM_INSTALL_DIRECTORY=/datadrive/IBM/InstallationManager/V1.9
+WAS_BASE_INSTALL_DIRECTORY=/datadrive/IBM/WebSphere/Base/V9
+IM_SHARED_DIRECTORY=/datadrive/IBM/IMShared
+SSL_PREF="com.ibm.cic.common.core.preferences.ssl.nonsecureMode=false"
+DOWNLOAD_PREF="com.ibm.cic.common.core.preferences.preserveDownloadedArtifacts=false"
+WAS_LOG_PATH=/var/log/cloud-init-was.log
+UNENTITLED=Unentitled
+ENTITLED=Entitled
+UNDEFINED=Undefined

--- a/twas-base/src/main/scripts/was-check.sh
+++ b/twas-base/src/main/scripts/was-check.sh
@@ -36,7 +36,7 @@ if [ ${#ibmIdCredentials[@]} -eq 2 ]; then
     fi
     
     output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl listAvailablePackages -cPA -secureStorageFile storage_file)
-    echo $output | grep -q "$WAS_ND_VERSION_ENTITLED" && result=$ENTITLED
+    echo $output | grep -q "$WAS_BASE_VERSION_ENTITLED" && result=$ENTITLED
     echo $output | grep -q "$NO_PACKAGES_FOUND" && result=$UNDEFINED
 else
     echo "Invalid input format." >> $WAS_LOG_PATH

--- a/twas-base/src/main/scripts/was-check.sh
+++ b/twas-base/src/main/scripts/was-check.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+#      Copyright (c) Microsoft Corporation.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+# 
+#           http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Get tWAS installation properties
+source /datadrive/virtualimage.properties
+
+echo "$(date): Start to check entitlement." > $WAS_LOG_PATH
+
+# Read custom data from ovf-env.xml
+customData=`xmllint --xpath "//*[local-name()='Environment']/*[local-name()='ProvisioningSection']/*[local-name()='LinuxProvisioningConfigurationSet']/*[local-name()='CustomData']/text()" /var/lib/waagent/ovf-env.xml`
+read -r -a ibmIdCredentials <<< "$(echo $customData | base64 -d)"
+
+# Check whether IBMid is entitled or not
+result=$UNENTITLED
+if [ ${#ibmIdCredentials[@]} -eq 2 ]; then
+    userName=${ibmIdCredentials[0]}
+    password=${ibmIdCredentials[1]}
+    
+    ${IM_INSTALL_DIRECTORY}/eclipse/tools/imutilsc saveCredential -secureStorageFile storage_file \
+        -userName "$userName" -userPassword "$password" -passportAdvantage
+    if [ $? -ne 0 ]; then
+        echo "Cannot connect to Passport Advantage while saving the credential to the secure storage file." >> $WAS_LOG_PATH
+    fi
+    
+    output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl listAvailablePackages -cPA -secureStorageFile storage_file)
+    echo $output | grep -q "$WAS_ND_VERSION_ENTITLED" && result=$ENTITLED
+    echo $output | grep -q "$NO_PACKAGES_FOUND" && result=$UNDEFINED
+else
+    echo "Invalid input format." >> $WAS_LOG_PATH
+fi
+
+echo "$(date): Entitlement check completed, start to update WebSphere installation." >> $WAS_LOG_PATH
+if [ ${result} = $ENTITLED ]; then
+    # Update all packages for the entitled user
+    output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl updateAll -repositories "$REPOSITORY_URL" \
+        -acceptLicense -log log_file -installFixes recommended -secureStorageFile storage_file -preferences $SSL_PREF,$DOWNLOAD_PREF -showProgress)
+    echo "$output" >> $WAS_LOG_PATH
+else
+    # Remove tWAS installation for the un-entitled or undefined user
+    output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl uninstall "$WAS_BASE_TRADITIONAL" "$IBM_JAVA_SDK" -installationDirectory ${WAS_BASE_INSTALL_DIRECTORY})
+    echo "$output" >> $WAS_LOG_PATH
+    rm -rf /datadrive/IBM && rm -rf /datadrive/virtualimage.properties
+fi
+echo "$(date): WebSphere installation updated." >> $WAS_LOG_PATH
+echo ${result} >> $WAS_LOG_PATH
+
+# Scrub the custom data from files which contain sensitive information
+if grep -q "CustomData" /var/lib/waagent/ovf-env.xml; then
+    sed -i "s/${customData}/REDACTED/g" /var/lib/waagent/ovf-env.xml
+    sed -i "s/Unhandled non-multipart (text\/x-not-multipart) userdata: 'b'.*'...'/Unhandled non-multipart (text\/x-not-multipart) userdata: 'b'REDACTED'...'/g" /var/log/cloud-init.log
+    sed -i "s/Unhandled non-multipart (text\/x-not-multipart) userdata: 'b'.*'...'/Unhandled non-multipart (text\/x-not-multipart) userdata: 'b'REDACTED'...'/g" /var/log/cloud-init-output.log
+fi
+
+# Remove temporary files
+rm -rf storage_file && rm -rf log_file


### PR DESCRIPTION
## Description
This PR is to address the following issues:
* resolve WASdev/azure.websphere-traditional.singleserver/issues/1

## Change summary
* Implement an ARM template to install a RHEL 8.4 VM on Azure with tWAS base and IBM Java JDK installed
* Implement cloud-init script to do entitlement check and upgrade
* Add entitlement check in `install.sh` to fail fast if the user account is unentitled

## Test cases
The following cases have already been verified before sending out the PR:
* Successfully deployed a RHEL 8.4 VM on Azure where with tWAS base and IBM Java JDK installed:
   * Installed com.ibm.websphere.BASE.v90_9.0.5010.20211108_1200 to the /datadrive/IBM/WebSphere/Base/V9/ directory.
   * Installed com.ibm.java.jdk.v8_8.0.7000.20211025_1430 to the /datadrive/IBM/WebSphere/Base/V9/ directory. 
* Successfully created a private image based on the above VM;
* Successfully deployed a RHEL 8.4 VM with tWAS base and IBM Java JDK installed using the above private image, for an entitled IBMid;
* Successfully deployed a RHEL 8.4 VM **without** tWAS base and IBM Java JDK installed using the above private image, for a non-entitled IBMid;

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>