### PR TITLE
Fix pipeline failure of `azure.websphere-traditional.image`

### DIFF
--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -9,7 +9,7 @@ on:
   # Allows you to run this workflow using GitHub APIs
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
   # REPO_NAME=WASdev/azure.websphere-traditional.image
-  # curl --verbose -XPOST -u "WASdev:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/actions/workflows/ihsBuild.yml/dispatches --data '{"ref": "master"}'
+  # curl --verbose -XPOST -u "WASdev:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/actions/workflows/ihsBuild.yml/dispatches --data '{"ref": "main"}'
   repository_dispatch:
     types: [ihs-integration-test]
   # sample request
@@ -19,7 +19,7 @@ on:
 
 env:
   # Latest version is at https://github.com/Azure/azure-cli/releases
-  azCliVersion: 2.23.0
+  azCliVersion: 2.31.0
   # Commit hash from https://github.com/Azure/azure-javaee-iaas/commits/main
   ref_javaee: 85d5d10dd045a90452ae01cad20b258ce853ec18
   # Commit hash from https://github.com/Azure/arm-ttk/commits/master
@@ -77,7 +77,7 @@ jobs:
         run: mvn -DskipTests clean install --file azure-javaee-iaas/pom.xml
       - name: Build and test
         run: |
-          # Add -Dgit.tag=<your local branch> if you are not using master
+          # Add -Dgit.tag=<your local branch> if you are not using main
           mvn -Dgit.repo=${{ env.userName }} -DibmUserId=${{ env.entitledIbmUserId }} -DibmUserPwd=${{ env.entitledIbmPassword }} -DvmName=${{ env.vmName }} -DvmAdminId=${{ env.vmAdminId }} -DvmAdminPwd=${{ env.vmAdminPassword }} -DdnsLabelPrefix=wsp -Dtest.args="-Test All" -Ptemplate-validation-tests -Dtemplate.validation.tests.directory=../../arm-ttk/arm-ttk clean install --file ${{ env.offerName }}/ihs/pom.xml
       - uses: azure/login@v1
         id: azure-login

--- a/.github/workflows/twas-ndBuild.yml
+++ b/.github/workflows/twas-ndBuild.yml
@@ -9,7 +9,7 @@ on:
   # Allows you to run this workflow using GitHub APIs
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
   # REPO_NAME=WASdev/azure.websphere-traditional.image
-  # curl --verbose -XPOST -u "WASdev:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/actions/workflows/twas-ndBuild.yml/dispatches --data '{"ref": "master"}'
+  # curl --verbose -XPOST -u "WASdev:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/actions/workflows/twas-ndBuild.yml/dispatches --data '{"ref": "main"}'
   repository_dispatch:
     types: [twas-integration-test]
   # sample request
@@ -19,7 +19,7 @@ on:
 
 env:
   # Latest version is at https://github.com/Azure/azure-cli/releases
-  azCliVersion: 2.23.0
+  azCliVersion: 2.31.0
   # Commit hash from https://github.com/Azure/azure-javaee-iaas/commits/main
   ref_javaee: 85d5d10dd045a90452ae01cad20b258ce853ec18
   # Commit hash from https://github.com/Azure/arm-ttk/commits/master
@@ -75,7 +75,7 @@ jobs:
         run: mvn -DskipTests clean install --file azure-javaee-iaas/pom.xml
       - name: Build and test
         run: |
-          # Add -Dgit.tag=<your local branch> if you are not using master
+          # Add -Dgit.tag=<your local branch> if you are not using main
           mvn -Dgit.repo=${{ env.userName }} -DibmUserId=${{ env.entitledIbmUserId }} -DibmUserPwd=${{ env.entitledIbmPassword }} -DvmName=${{ env.vmName }} -DvmAdminId=${{ env.vmAdminId }} -DvmAdminPwd=${{ env.vmAdminPassword }} -DdnsLabelPrefix=wsp -Dtest.args="-Test All" -Ptemplate-validation-tests -Dtemplate.validation.tests.directory=../../arm-ttk/arm-ttk clean install --file ${{ env.offerName }}/twas-nd/pom.xml
       - uses: azure/login@v1
         id: azure-login

--- a/ihs/pom.xml
+++ b/ihs/pom.xml
@@ -36,7 +36,7 @@
         <git.proj>azure.websphere-traditional.image</git.proj>
         <git.repo>WASdev</git.repo>
         <!-- 
-            The default value for `git.tag` is defined in parent pom "azure-javaee-iaas-parent", which is `master`.
+            The default value for `git.tag` is defined in parent pom "azure-javaee-iaas-parent", which is `main`.
             It can also be overridden with `-Dgit.tag` at the maven command line if you use a different git branch.
             See https://github.com/Azure/azure-javaee-iaas/blob/main/arm-parent/pom.xml#L22-L24 for more available properties.
          -->

--- a/twas-nd/pom.xml
+++ b/twas-nd/pom.xml
@@ -35,7 +35,7 @@
     <properties>
         <git.repo>WASdev</git.repo>
         <!-- 
-            The default value for `git.tag` is defined in parent pom "azure-javaee-iaas-parent", which is `master`.
+            The default value for `git.tag` is defined in parent pom "azure-javaee-iaas-parent", which is `main`.
             It can also be overridden with `-Dgit.tag` at the maven command line if you use a different git branch.
             See https://github.com/Azure/azure-javaee-iaas/blob/main/arm-parent/pom.xml#L22-L24 for more available properties.
          -->


### PR DESCRIPTION
The PR is to resolve WASdev/azure.websphere-traditional.cluster/issues/126 by upgrading version of az cli.
The fix is tested and verified, see https://github.com/majguo/azure.websphere-traditional.image/runs/4515945537?check_suite_focus=true 

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>