### PR TITLE
Setup cicd pipeline for base image of twas single server

### DIFF
--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -11,11 +11,12 @@ on:
   # REPO_NAME=WASdev/azure.websphere-traditional.image
   # curl --verbose -XPOST -u "WASdev:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/actions/workflows/ihsBuild.yml/dispatches --data '{"ref": "main"}'
   repository_dispatch:
-    types: [ihs-integration-test]
+    types: [ihs-integration-test, integration-test]
   # sample request
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
   # REPO_NAME=WASdev/azure.websphere-traditional.image
   # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "ihs-integration-test"}'
+  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test"}'
 
 env:
   # Latest version is at https://github.com/Azure/azure-cli/releases

--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -11,12 +11,12 @@ on:
   # REPO_NAME=WASdev/azure.websphere-traditional.image
   # curl --verbose -XPOST -u "WASdev:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/actions/workflows/ihsBuild.yml/dispatches --data '{"ref": "main"}'
   repository_dispatch:
-    types: [ihs-integration-test, integration-test]
+    types: [integration-test-ihs, integration-test-all]
   # sample request
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
   # REPO_NAME=WASdev/azure.websphere-traditional.image
-  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "ihs-integration-test"}'
-  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test"}'
+  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test-ihs"}'
+  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test-all"}'
 
 env:
   # Latest version is at https://github.com/Azure/azure-cli/releases

--- a/.github/workflows/twas-baseBuild.yml
+++ b/.github/workflows/twas-baseBuild.yml
@@ -19,7 +19,7 @@ on:
 
 env:
   # Latest version is at https://github.com/Azure/azure-cli/releases
-  azCliVersion: 2.23.0
+  azCliVersion: 2.31.0
   # Commit hash from https://github.com/Azure/azure-javaee-iaas/commits/main
   ref_javaee: 85d5d10dd045a90452ae01cad20b258ce853ec18
   # Commit hash from https://github.com/Azure/arm-ttk/commits/master

--- a/.github/workflows/twas-baseBuild.yml
+++ b/.github/workflows/twas-baseBuild.yml
@@ -11,11 +11,12 @@ on:
   # REPO_NAME=WASdev/azure.websphere-traditional.image
   # curl --verbose -XPOST -u "WASdev:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/actions/workflows/twas-baseBuild.yml/dispatches --data '{"ref": "main"}'
   repository_dispatch:
-    types: [twas-integration-test]
+    types: [twasbase-integration-test, integration-test]
   # sample request
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
   # REPO_NAME=WASdev/azure.websphere-traditional.image
-  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "twas-integration-test"}'
+  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "twasbase-integration-test"}'
+  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test"}'
 
 env:
   # Latest version is at https://github.com/Azure/azure-cli/releases
@@ -31,7 +32,7 @@ env:
   unEntitledIbmPassword: ${{ secrets.UNENTITLED_IBM_USER_PWD }}
   entitledIbmUserId: ${{ secrets.ENTITLED_IBM_USER_ID }}
   entitledIbmPassword: ${{ secrets.ENTITLED_IBM_USER_PWD }}
-  vmName: was${{ github.run_id }}${{ github.run_number }}
+  vmName: twasbase${{ github.run_id }}${{ github.run_number }}
   vmAdminId: ${{ secrets.VM_ADMIN_ID }}
   vmAdminPassword: ${{ secrets.VM_ADMIN_PASSWORD }}
   testResourceGroup: imageTest${{ github.run_id }}${{ github.run_number }}

--- a/.github/workflows/twas-baseBuild.yml
+++ b/.github/workflows/twas-baseBuild.yml
@@ -21,7 +21,7 @@ env:
   # Latest version is at https://github.com/Azure/azure-cli/releases
   azCliVersion: 2.31.0
   # Commit hash from https://github.com/Azure/azure-javaee-iaas/commits/main
-  ref_javaee: 85d5d10dd045a90452ae01cad20b258ce853ec18
+  ref_javaee: 13fe6ec487024eb61355d661ab5700ae90cb0a8f
   # Commit hash from https://github.com/Azure/arm-ttk/commits/master
   ref_armttk: d97aa57d259e2fc8562e11501b1cf902265129d9
   offerName: azure.websphere-traditional.image

--- a/.github/workflows/twas-baseBuild.yml
+++ b/.github/workflows/twas-baseBuild.yml
@@ -1,0 +1,376 @@
+# This is a basic workflow to help you get started with Actions
+
+name: twas-base CICD
+
+# Controls when the action will run. 
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+  # Allows you to run this workflow using GitHub APIs
+  # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
+  # REPO_NAME=WASdev/azure.websphere-traditional.image
+  # curl --verbose -XPOST -u "WASdev:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/actions/workflows/twas-baseBuild.yml/dispatches --data '{"ref": "main"}'
+  repository_dispatch:
+    types: [twas-integration-test]
+  # sample request
+  # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
+  # REPO_NAME=WASdev/azure.websphere-traditional.image
+  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "twas-integration-test"}'
+
+env:
+  # Latest version is at https://github.com/Azure/azure-cli/releases
+  azCliVersion: 2.23.0
+  # Commit hash from https://github.com/Azure/azure-javaee-iaas/commits/main
+  ref_javaee: 85d5d10dd045a90452ae01cad20b258ce853ec18
+  # Commit hash from https://github.com/Azure/arm-ttk/commits/master
+  ref_armttk: d97aa57d259e2fc8562e11501b1cf902265129d9
+  offerName: azure.websphere-traditional.image
+  userName: ${{ secrets.USER_NAME }}
+  azureCredentials: ${{ secrets.AZURE_CREDENTIALS }}
+  unEntitledIbmUserId: ${{ secrets.UNENTITLED_IBM_USER_ID }}
+  unEntitledIbmPassword: ${{ secrets.UNENTITLED_IBM_USER_PWD }}
+  entitledIbmUserId: ${{ secrets.ENTITLED_IBM_USER_ID }}
+  entitledIbmPassword: ${{ secrets.ENTITLED_IBM_USER_PWD }}
+  vmName: was${{ github.run_id }}${{ github.run_number }}
+  vmAdminId: ${{ secrets.VM_ADMIN_ID }}
+  vmAdminPassword: ${{ secrets.VM_ADMIN_PASSWORD }}
+  testResourceGroup: imageTest${{ github.run_id }}${{ github.run_number }}
+  vhdStorageAccountName: storage${{ github.run_id }}${{ github.run_number }}
+  msTeamsWebhook: ${{ secrets.MSTEAMS_WEBHOOK }}
+  location: eastus
+  # Installation directory, must be updated if virtualimage.properties/WAS_BASE_INSTALL_DIRECTORY changed 
+  was_base_install_directory: /datadrive/IBM/WebSphere/Base/V9
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - name: Checkout azure-javaee-iaas
+        uses: actions/checkout@v2
+        with:
+          repository: Azure/azure-javaee-iaas
+          path: azure-javaee-iaas
+          ref: ${{ env.ref_javaee }}
+
+      - name: Checkout arm-ttk
+        uses: actions/checkout@v2
+        with:
+          repository: Azure/arm-ttk
+          path: arm-ttk
+          ref: ${{ env.ref_armttk }}
+      # Checks-out your repository `under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+        with:
+          path: ${{ env.offerName }}
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build azure-javaee-iaas
+        run: mvn -DskipTests clean install --file azure-javaee-iaas/pom.xml
+      - name: Build and test
+        run: |
+          # Add -Dgit.tag=<your local branch> if you are not using main
+          mvn -Dgit.repo=${{ env.userName }} -DibmUserId=${{ env.entitledIbmUserId }} -DibmUserPwd=${{ env.entitledIbmPassword }} -DvmAdminId=${{ env.vmAdminId }} -DvmAdminPwd=${{ env.vmAdminPassword }} -DdnsLabelPrefix=wsp -Dtest.args="-Test All" -Ptemplate-validation-tests -Dtemplate.validation.tests.directory=../../arm-ttk/arm-ttk clean install --file ${{ env.offerName }}/twas-base/pom.xml
+      - uses: azure/login@v1
+        id: azure-login
+        with:
+          creds: ${{ env.azureCredentials }}
+      - name: Create image test resource group
+        run: |
+          az group create -l ${{ env.location }} -n ${{ env.testResourceGroup }}
+      - name: Run deployment script
+        run: |
+          cd ${{ env.offerName }}/twas-base/target/arm
+
+          #parameters JSON
+          parametersJson=$( cat ./parameters.json | jq '.parameters' )
+          parametersJson=$( echo "$parametersJson" | jq --arg storageAccount "${{ env.vhdStorageAccountName }}" '{"storageAccount": {"value":$storageAccount}} + .' )
+          parametersJson=$( echo "$parametersJson" | jq --arg vmName "${{ env.vmName }}" '{"vmName": {"value":$vmName}} + .' )
+
+          #Start deployment
+          echo "Starting deployment..."
+          (
+            az deployment group create --name ${{ github.run_id }}${{ github.run_number }} --resource-group ${{ env.testResourceGroup }} \
+              --template-file ./mainTemplate.json --parameters "$parametersJson"
+          )
+
+          if [[ $? -eq 0 ]]; then
+            echo "Template has been successfully deployed"
+          fi
+      - name: Query public IP of VM
+        id: query-vm-ip
+        uses: azure/CLI@v1
+        with:
+          azcliversion: ${{ env.azCliVersion }}
+          inlineScript: |
+            echo "query public ip"
+            publicIP=$(az vm show \
+              --resource-group ${{ env.testResourceGroup }} \
+              --name ${{ env.vmName }} -d \
+              --query publicIps -o tsv)
+            echo "##[set-output name=publicIP;]${publicIP}"
+      - name: Create environment variable for VM
+        id: env-vm-ip
+        run: echo "wlsPublicIP=${{steps.query-vm-ip.outputs.publicIP}}" >> $GITHUB_ENV
+      - name: Install cifs-utils
+        run: |
+          echo "pubilc IP of VM: ${wlsPublicIP}"
+          echo "yum update starts"
+          echo install sshpass
+          sudo apt-get install -y sshpass
+          timeout 1m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${wlsPublicIP} 22
+          sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo  -S yum install cifs-utils -y'
+      - name: Update applications
+        run: |
+          echo "pubilc IP of VM: ${wlsPublicIP}"
+          echo "yum update starts"
+          echo install sshpass
+          sudo apt-get install -y sshpass
+          timeout 1m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${wlsPublicIP} 22
+          sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S yum update -y'
+      - name: Deprovision
+        run: |
+          echo "pubilc IP of VM: ${wlsPublicIP}"
+          echo "Deprovision starts"
+          echo install sshpass
+          sudo apt-get install -y sshpass
+          timeout 1m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${wlsPublicIP} 22
+          sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S waagent -deprovision+user -force'
+      - name: Generate VM Image
+        run: |
+          # Update the access level of vhd container
+          vhdStorageAccountAccessKey=$(az storage account keys list --account-name ${{ env.vhdStorageAccountName }} --query "[?keyName=='key1'].value" -o tsv)
+          echo ${vhdStorageAccountAccessKey}
+          az storage container set-permission --account-name ${{ env.vhdStorageAccountName }} --account-key ${vhdStorageAccountAccessKey} --name vhds --public-access container
+          # Create the image
+          az vm deallocate --resource-group ${{ env.testResourceGroup }} --name ${{ env.vmName }}
+          az vm generalize --resource-group ${{ env.testResourceGroup }} --name ${{ env.vmName }}
+          az image create --resource-group ${{ env.testResourceGroup }} --name ${{ env.vmName }} --source ${{ env.vmName }}
+      - name: Deploy VM using image with unentitled account
+        run: |
+          imageResourceId=$(az image show --name ${{ env.vmName }} --resource-group ${{ env.testResourceGroup }} --query id -o tsv)
+          cd ${{ env.offerName }}/twas-base/test
+          az deployment group create --resource-group ${{ env.testResourceGroup }} \
+              --name unentitled${{ github.run_id }}${{ github.run_number }} \
+              --template-file ./mainTemplate.json \
+              --parameters ibmUserId=${{ env.unEntitledIbmUserId }} ibmUserPwd=${{ env.unEntitledIbmPassword }} vmName=unentitled${{ github.run_id }}${{ github.run_number }} vmAdminId=${{ env.vmAdminId }} vmAdminPwd=${{ env.vmAdminPassword }} location=${{ env.location }} imageResourceId=$imageResourceId
+      - name: Verify that the IBM installations for unentitled vm
+        run: |
+          echo "query public ip"
+          untitledVMIP=$(az vm show \
+            --resource-group ${{ env.testResourceGroup }} \
+            --name unentitled${{ github.run_id }}${{ github.run_number }} -d \
+            --query publicIps -o tsv)
+          echo "pubilc IP of VM: ${untitledVMIP}"
+          echo "Verifying WebSphere server installation"
+          echo install sshpass
+          sudo apt-get install -y sshpass
+          timeout 3m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${untitledVMIP} 22
+
+          isCloudInitReady=false
+          while [ $isCloudInitReady = false ]
+          do
+            isCloudInitReady=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${untitledVMIP} 'if [ ! -f "/var/log/cloud-init-was.log" ]; then echo false; else echo true; fi')
+            if [[ $isCloudInitReady = false ]]; then
+              echo "waiting for was entitlement check started..."
+              sleep 5
+            else
+              echo "was entitlement check started..."
+            fi
+          done
+
+          isDone=false
+          while [ $isDone = false ]
+          do
+            result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${untitledVMIP} '(tail -n1) </var/log/cloud-init-was.log')
+            # Remove special characters
+            result=$(echo $result | sed $'s/[^[:alnum:]\t]//g')
+            if [[ "$result" == "Unentitled" ]] || [[ "$result" == "Entitled" ]] || [[ "$result" == "Undefined" ]]; then
+                isDone=true
+            else
+                echo "waiting for was entitlement check completed..."
+                sleep 5
+            fi
+          done
+          echo $result
+
+          if [ ${result} = Entitled ]; then
+              exit 1
+          fi
+
+          # Check the installation path is not removed
+          echo "Check the installation path is not removed"
+          pathExists=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${untitledVMIP} 'if [ -d "${{ env.was_base_install_directory }}" ]; then echo true; else echo false; fi')
+          if [[ $pathExists = true ]]; then
+            echo "IBM installations still exist"
+            exit 1
+          fi
+
+      - name: Deploy VM using image with entitled account
+        run: |
+          imageResourceId=$(az image show --name ${{ env.vmName }} --resource-group ${{ env.testResourceGroup }} --query id -o tsv)
+          cd ${{ env.offerName }}/twas-base/test
+          az deployment group create --resource-group ${{ env.testResourceGroup }} \
+              --name entitled${{ github.run_id }}${{ github.run_number }} \
+              --template-file ./mainTemplate.json \
+              --parameters ibmUserId=${{ env.entitledIbmUserId }} ibmUserPwd=${{ env.entitledIbmPassword }} vmName=entitled${{ github.run_id }}${{ github.run_number }} vmAdminId=${{ env.vmAdminId }} vmAdminPwd=${{ env.vmAdminPassword }} location=${{ env.location }} imageResourceId=$imageResourceId
+      - name: Verify that the IBM installations for entitled vm
+        run: |
+          echo "query public ip"
+          entitledVMIP=$(az vm show \
+            --resource-group ${{ env.testResourceGroup }} \
+            --name entitled${{ github.run_id }}${{ github.run_number }} -d \
+            --query publicIps -o tsv)
+          echo "pubilc IP of VM: ${entitledVMIP}"
+          echo "Verifying WebSphere server installation"
+          echo install sshpass
+          sudo apt-get install -y sshpass
+          timeout 1m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${entitledVMIP} 22
+          isCloudInitReady=false
+          while [ $isCloudInitReady = false ]
+          do
+            isCloudInitReady=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} 'if [ ! -f "/var/log/cloud-init-was.log" ]; then echo false; else echo true; fi')
+            if [[ $isCloudInitReady = false ]]; then
+              echo "waiting for was entitlement check started..."
+              sleep 5
+            else
+              echo "was entitlement check started..."
+            fi
+          done
+
+          isDone=false
+          while [ $isDone = false ]
+          do
+            result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} '(tail -n1) </var/log/cloud-init-was.log')
+            # Remove special characters
+            result=$(echo $result | sed $'s/[^[:alnum:]\t]//g')
+            if [[ "$result" == "Unentitled" ]] || [[ "$result" == "Entitled" ]] || [[ "$result" == "Undefined" ]]; then
+                isDone=true
+            else
+                echo "waiting for was entitlement check completed..."
+                sleep 5
+            fi
+          done
+          echo $result
+
+          if [ ${result} != Entitled ]; then
+              exit 1
+          fi
+          
+          # Check the installation path is removed
+          echo "Check the installation path is removed"
+          pathExists=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} 'if [ -d "${{ env.was_base_install_directory }}" ]; then echo true; else echo false; fi')
+          if [[ $pathExists = false ]]; then
+            echo "IBM installations do not exist"
+            exit 1
+          fi
+      - name: Generate SAS url
+        id: generate-sas-blob-url
+        run: |
+          #Get a minus-24-hour date for the SAS token
+          minus24HoursUtc=$(date -u --date "$dte -24 hour" +%Y-%m-%dT%H:%MZ)
+          echo $minus24HoursUtc
+
+          #Get a plus-30-day date for the SAS token
+          plus30DaysUtc=$(date -u --date "$dte 30 day" +%Y-%m-%dT%H:%MZ)
+          echo $plus30DaysUtc
+
+          vhdStorageAccountAccessKey=$(az storage account keys list --account-name ${{ env.vhdStorageAccountName }} --query "[?keyName=='key1'].value" -o tsv)
+          echo ${vhdStorageAccountAccessKey}
+
+          sasTokenForOffer=$(az storage container generate-sas --connection-string "DefaultEndpointsProtocol=https;AccountName=${{ env.vhdStorageAccountName }};AccountKey=${vhdStorageAccountAccessKey};EndpointSuffix=core.windows.net" --name vhds --permissions rl --start "${minus24HoursUtc}" --expiry "${plus30DaysUtc}" -o tsv)
+          echo $sasTokenForOffer
+
+          blobStorageEndpoint=$( az storage account show -n ${{ env.vhdStorageAccountName }} -g ${{ env.testResourceGroup }} -o json | jq -r '.primaryEndpoints.blob' )
+          echo $blobStorageEndpoint
+
+          osDiskSasUrl=${blobStorageEndpoint}vhds/${{ env.vmName }}.vhd?$sasTokenForOffer
+          echo "osDiskSasUrl: ${osDiskSasUrl}"
+          dataDiskSasUrl=${blobStorageEndpoint}vhds/${{ env.vmName }}datadisk1.vhd?$sasTokenForOffer
+          echo "dataDiskSasUrl: ${dataDiskSasUrl}"
+          
+          echo "osDiskSasUrl: ${osDiskSasUrl}, dataDiskSasUrl: ${dataDiskSasUrl}" > sas-url.txt
+          sasUrls=`cat sas-url.txt`
+          echo "sas-url: ${sasUrls}"
+      - name: Upload sas-url.txt
+        uses: actions/upload-artifact@v2
+        with:
+          name: sasurl
+          path: sas-url.txt
+
+      - name: Delete all resources but vhd storage account in the test resource group
+        id: delete-resources-in-group
+        if: always()
+        uses: azure/CLI@v1
+        with:
+          azcliversion: ${{ env.azCliVersion }}
+          inlineScript: |
+            # Disks have to be deleted after the VM is deleted
+            unentitledOsDiskId=$(az vm show --resource-group ${{ env.testResourceGroup }} --name unentitled${{ github.run_id }}${{ github.run_number }} --query "storageProfile.osDisk.managedDisk.id" -o tsv)
+            echo "unentitledOsDiskId: ${unentitledOsDiskId}"
+
+            unentitledDataDiskIds=$(az vm show --resource-group ${{ env.testResourceGroup }} --name unentitled${{ github.run_id }}${{ github.run_number }} --query "storageProfile.dataDisks" | jq -r 'map(.managedDisk.id) | join(" ")')
+            echo "unentitledDataDiskIds: ${unentitledDataDiskIds}"
+
+            entitledOsDiskId=$(az vm show --resource-group ${{ env.testResourceGroup }} --name entitled${{ github.run_id }}${{ github.run_number }} --query "storageProfile.osDisk.managedDisk.id" -o tsv)
+            echo "unentitledOsDiskId: ${unentitledOsDiskId}"
+
+            entitledDataDiskIds=$(az vm show --resource-group ${{ env.testResourceGroup }} --name entitled${{ github.run_id }}${{ github.run_number }} --query "storageProfile.dataDisks" | jq -r 'map(.managedDisk.id) | join(" ")')
+            echo "unentitledDataDiskIds: ${unentitledDataDiskIds}"
+
+            vmForImage=$(az vm list --resource-group ${{ env.testResourceGroup }} --query "[?name=='${{ env.vmName }}']" | jq -r 'map(.id) | join(" ")')
+            echo $vmForImage
+
+            resourcesToDelete=$(az resource list --query "[?name!='${{ env.vhdStorageAccountName }}']" --resource-group ${{ env.testResourceGroup }} | jq -r 'map(.id) | join(" ")')
+            echo $resourcesToDelete
+
+            az vm delete --verbose --ids $vmForImage --yes
+            az resource delete --verbose --ids $resourcesToDelete
+            az disk delete --yes --resource-group ${{ env.testResourceGroup }} --ids ${unentitledOsDiskId} ${unentitledDataDiskIds} ${entitledOsDiskId} ${entitledDataDiskIds}
+  summary:
+    needs: build
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download sas-url.txt
+        uses: actions/download-artifact@v2
+        with:
+          name: sasurl
+      - name: summarize jobs
+        if: always()
+        run: |
+            workflow_jobs=$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/WASdev/azure.websphere-traditional.image/actions/runs/${{ github.run_id }}/jobs)
+
+            success_build_job=$(echo $workflow_jobs | jq '.jobs | map(select(.name=="build" and .conclusion=="success")) | length')
+            echo "$success_build_job"
+            if (($success_build_job == 0));then
+                echo "Job failed, send notification to Teams"
+                curl ${{ env.msTeamsWebhook }} \
+                -H 'Content-Type: application/json' \
+                --data-binary @- << EOF
+                {
+                "@context":"http://schema.org/extensions",
+                "@type":"MessageCard",
+                "text":"Workflow of repo 'azure.websphere-traditional.image/twas-base' failed, please take a look at: https://github.com/WASdev/azure.websphere-traditional.image/actions/runs/${{ github.run_id }}"
+                }
+            EOF
+            else
+                echo "Job succeed, send notification to Teams"
+                sasUrls=`cat sas-url.txt`
+                echo ${sasUrls}
+                curl ${{ env.msTeamsWebhook }} \
+                -H 'Content-Type: application/json' \
+                --data-binary @- << EOF
+                {
+                "@context":"http://schema.org/extensions",
+                "@type":"MessageCard",
+                "text":"Workflow of repo 'azure.websphere-traditional.image/twas-base' succeeded, ${sasUrls}"
+                }
+            EOF
+            fi

--- a/.github/workflows/twas-baseBuild.yml
+++ b/.github/workflows/twas-baseBuild.yml
@@ -11,12 +11,12 @@ on:
   # REPO_NAME=WASdev/azure.websphere-traditional.image
   # curl --verbose -XPOST -u "WASdev:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/actions/workflows/twas-baseBuild.yml/dispatches --data '{"ref": "main"}'
   repository_dispatch:
-    types: [twasbase-integration-test, integration-test]
+    types: [integration-test-twasbase, integration-test-all]
   # sample request
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
   # REPO_NAME=WASdev/azure.websphere-traditional.image
-  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "twasbase-integration-test"}'
-  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test"}'
+  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test-twasbase"}'
+  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test-all"}'
 
 env:
   # Latest version is at https://github.com/Azure/azure-cli/releases

--- a/.github/workflows/twas-ndBuild.yml
+++ b/.github/workflows/twas-ndBuild.yml
@@ -11,12 +11,12 @@ on:
   # REPO_NAME=WASdev/azure.websphere-traditional.image
   # curl --verbose -XPOST -u "WASdev:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/actions/workflows/twas-ndBuild.yml/dispatches --data '{"ref": "main"}'
   repository_dispatch:
-    types: [twasnd-integration-test, integration-test]
+    types: [integration-test-twasnd, integration-test-all]
   # sample request
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
   # REPO_NAME=WASdev/azure.websphere-traditional.image
-  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "twasnd-integration-test"}'
-  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test"}'
+  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test-twasnd"}'
+  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test-all"}'
 
 env:
   # Latest version is at https://github.com/Azure/azure-cli/releases

--- a/.github/workflows/twas-ndBuild.yml
+++ b/.github/workflows/twas-ndBuild.yml
@@ -11,11 +11,12 @@ on:
   # REPO_NAME=WASdev/azure.websphere-traditional.image
   # curl --verbose -XPOST -u "WASdev:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/actions/workflows/twas-ndBuild.yml/dispatches --data '{"ref": "main"}'
   repository_dispatch:
-    types: [twas-integration-test]
+    types: [twasnd-integration-test, integration-test]
   # sample request
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
   # REPO_NAME=WASdev/azure.websphere-traditional.image
-  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "twas-integration-test"}'
+  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "twasnd-integration-test"}'
+  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test"}'
 
 env:
   # Latest version is at https://github.com/Azure/azure-cli/releases
@@ -31,7 +32,7 @@ env:
   unEntitledIbmPassword: ${{ secrets.UNENTITLED_IBM_USER_PWD }}
   entitledIbmUserId: ${{ secrets.ENTITLED_IBM_USER_ID }}
   entitledIbmPassword: ${{ secrets.ENTITLED_IBM_USER_PWD }}
-  vmName: was${{ github.run_id }}${{ github.run_number }}
+  vmName: twasnd${{ github.run_id }}${{ github.run_number }}
   vmAdminId: ${{ secrets.VM_ADMIN_ID }}
   vmAdminPassword: ${{ secrets.VM_ADMIN_PASSWORD }}
   testResourceGroup: imageTest${{ github.run_id }}${{ github.run_number }}

--- a/twas-base/test/mainTemplate.json
+++ b/twas-base/test/mainTemplate.json
@@ -1,0 +1,205 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "location": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().location]"
+        },
+        "dnsLabelPrefix": {
+            "defaultValue": "wsp",
+            "type": "string"
+        },
+        "ibmUserId": {
+            "defaultValue": "",
+            "type": "string"
+        },
+        "ibmUserPwd": {
+            "defaultValue": "",
+            "type": "securestring"
+        },
+        "imageResourceId": {
+            "defaultValue": "",
+            "type": "string"
+        },
+        "vmSize": {
+            "defaultValue": "Standard_D2_v3",
+            "type": "string"
+        },
+        "vmName": {
+            "type": "string"
+        },
+        "addressPrefix": {
+            "defaultValue": "10.0.0.0/16",
+            "type": "string"
+        },
+        "subnetName": {
+            "defaultValue": "subnet01",
+            "type": "string"
+        },
+        "subnetAddressPrefix": {
+            "defaultValue": "10.0.1.0/24",
+            "type": "string"
+        },
+        "vmAdminId": {
+            "type": "string"
+        },
+        "vmAdminPwd": {
+            "type": "securestring"
+        },
+        "guidValue": {
+            "defaultValue": "[newGuid()]",
+            "type": "string"
+        }
+    },
+    "variables": {
+        "const_dnsLabelPrefix": "[concat(parameters('dnsLabelPrefix'), take(replace(parameters('guidValue'),'-',''),6))]",
+        "name_networkInterface": "[concat(variables('name_virtualMachine'), '-if')]",
+        "name_networkSecurityGroup": "[concat(variables('const_dnsLabelPrefix'), '-nsg')]",
+        "name_publicIPAddress": "[concat(variables('name_virtualMachine'), '-ip')]",
+        "name_virtualMachine": "[parameters('vmName')]",
+        "name_virtualNetwork": "[concat(variables('const_dnsLabelPrefix'), '-vnet')]",
+        "ref_networkInterface": "[resourceId('Microsoft.Network/networkInterfaces', variables('name_networkInterface'))]",
+        "ref_networkSecurityGroup": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('name_networkSecurityGroup'))]",
+        "ref_publicIPAddress": "[resourceId('Microsoft.Network/publicIPAddresses', variables('name_publicIPAddress'))]",
+        "ref_subnet": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('name_virtualNetwork'), parameters('subnetName'))]",
+        "ref_virtualNetwork": "[resourceId('Microsoft.Network/virtualNetworks', variables('name_virtualNetwork'))]"
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Network/networkSecurityGroups",
+            "apiVersion": "2019-06-01",
+            "name": "[variables('name_networkSecurityGroup')]",
+            "location": "[parameters('location')]",
+            "properties": {
+                "securityRules": [
+                    {
+                        "name": "TCP",
+                        "properties": {
+                            "protocol": "TCP",
+                            "sourcePortRange": "*",
+                            "sourceAddressPrefix": "*",
+                            "destinationAddressPrefix": "*",
+                            "access": "Allow",
+                            "priority": 320,
+                            "direction": "Inbound",
+                            "destinationPortRanges": [
+                                "22",
+                                "9043",
+                                "9060",
+                                "9080",
+                                "9443"
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Microsoft.Network/virtualNetworks",
+            "apiVersion": "2019-06-01",
+            "name": "[variables('name_virtualNetwork')]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[variables('ref_networkSecurityGroup')]"
+            ],
+            "properties": {
+                "addressSpace": {
+                    "addressPrefixes": [
+                        "[parameters('addressPrefix')]"
+                    ]
+                },
+                "enableDdosProtection": false,
+                "enableVmProtection": false
+            }
+        },
+        {
+            "type": "Microsoft.Network/virtualNetworks/subnets",
+            "apiVersion": "2019-06-01",
+            "name": "[concat(variables('name_virtualNetwork'), '/', parameters('subnetName'))]",
+            "dependsOn": [
+                "[variables('ref_virtualNetwork')]",
+                "[variables('ref_networkSecurityGroup')]"
+            ],
+            "properties": {
+                "addressPrefix": "[parameters('subnetAddressPrefix')]",
+                "networkSecurityGroup": {
+                    "id": "[variables('ref_networkSecurityGroup')]"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Network/publicIPAddresses",
+            "apiVersion": "2019-06-01",
+            "name": "[variables('name_publicIPAddress')]",
+            "location": "[parameters('location')]",
+            "properties": {
+                "publicIPAllocationMethod": "Dynamic",
+                "dnsSettings": {
+                    "domainNameLabel": "[variables('const_dnsLabelPrefix')]"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Network/networkInterfaces",
+            "apiVersion": "2019-06-01",
+            "name": "[variables('name_networkInterface')]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[variables('ref_publicIPAddress')]",
+                "[variables('ref_subnet')]"
+            ],
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "name": "ipconfig1",
+                        "properties": {
+                            "privateIPAllocationMethod": "Dynamic",
+                            "publicIPAddress": {
+                                "id": "[variables('ref_publicIPAddress')]"
+                            },
+                            "subnet": {
+                                "id": "[variables('ref_subnet')]"
+                            }
+                        }
+                    }
+                ],
+                "enableAcceleratedNetworking": false,
+                "enableIPForwarding": false,
+                "primary": true
+            }
+        },
+        {
+            "type": "Microsoft.Compute/virtualMachines",
+            "apiVersion": "2020-06-01",
+            "name": "[variables('name_virtualMachine')]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[variables('ref_networkInterface')]"
+            ],
+            "properties": {
+                "hardwareProfile": {
+                    "vmSize": "[parameters('vmSize')]"
+                },
+                "storageProfile": {
+                    "imageReference": {
+                        "id": "[parameters('imageResourceId')]"
+                    }
+                },
+                "osProfile": {
+                    "computerName": "[variables('name_virtualMachine')]",
+                    "adminUsername": "[parameters('vmAdminId')]",
+                    "adminPassword": "[parameters('vmAdminPwd')]",
+                    "customData": "[base64(concat(parameters('ibmUserId'), ' ', parameters('ibmUserPwd')))]"
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "id": "[variables('ref_networkInterface')]"
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
The PR is to resolve WASdev/azure.websphere-traditional.singleserver/issues/2 which:
* Invoke the arm template to deploy a RHEL 8.4 VM with tWAS base pre-installed
* Create a private image from the VM
* Verify the VM deployed from the private image for the un-entitled user has no tWAS base installed
* Verify the VM deployed from the private image for the entitled user has tWAS base installed
* Generate disk SAS URLs for both OS and data disks
* Upload the text file including disk SAS URLs to output of the build

See the [successful build](https://github.com/majguo/azure.websphere-traditional.image/runs/4591303312?check_suite_focus=true) in the fork.
* Note: ignore failed job `summary` as it tried to interact with `WASdev` repo where the pipeline doesn't exist, before this PR is merged. 

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>