### PR TITLE
Support both entitlement and evaluation

### DIFF
--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -414,7 +414,7 @@ jobs:
       - name: summarize jobs
         if: always()
         run: |
-            workflow_jobs=$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/WASdev/azure.websphere-traditional.image/actions/runs/${{ github.run_id }}/jobs)
+            workflow_jobs=$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${{ env.userName }}/azure.websphere-traditional.image/actions/runs/${{ github.run_id }}/jobs)
 
             success_build_job=$(echo $workflow_jobs | jq '.jobs | map(select(.name=="build" and .conclusion=="success")) | length')
             echo "$success_build_job"
@@ -426,7 +426,7 @@ jobs:
                 {
                 "@context":"http://schema.org/extensions",
                 "@type":"MessageCard",
-                "text":"Workflow of repo 'azure.websphere-traditional.image/ihs' failed, please take a look at: https://github.com/WASdev/azure.websphere-traditional.image/actions/runs/${{ github.run_id }}"
+                "text":"Workflow of repo 'azure.websphere-traditional.image/ihs' failed, please take a look at: https://github.com/${{ env.userName }}/azure.websphere-traditional.image/actions/runs/${{ github.run_id }}"
                 }
             EOF
             else

--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -183,10 +183,10 @@ jobs:
           do
             isCloudInitReady=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${untitledVMIP} 'if [ ! -f "/var/log/cloud-init-was.log" ]; then echo false; else echo true; fi')
             if [[ $isCloudInitReady = false ]]; then
-              echo "waiting for entitlement check started..."
+              echo "waiting for entitlement/evaluation check started..."
               sleep 5
             else
-              echo "entitlement check started..."
+              echo "entitlement/evaluation check started..."
             fi
           done
 
@@ -196,10 +196,10 @@ jobs:
             result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${untitledVMIP} '(tail -n1) </var/log/cloud-init-was.log')
             # Remove special characters
             result=$(echo $result | sed $'s/[^[:alnum:]\t]//g')
-            if [[ "$result" == "Unentitled" ]] || [[ "$result" == "Entitled" ]] || [[ "$result" == "Undefined" ]]; then
+            if [[ "$result" == "Unentitled" ]] || [[ "$result" == "Entitled" ]] || [[ "$result" == "Undefined" ]] || [[ "$result" = "Evaluation" ]]; then
                 isDone=true
             else
-                echo "waiting for entitlement check completed..."
+                echo "waiting for entitlement/evaluation check completed..."
                 sleep 5
             fi
           done
@@ -242,10 +242,10 @@ jobs:
           do
             isCloudInitReady=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} 'if [ ! -f "/var/log/cloud-init-was.log" ]; then echo false; else echo true; fi')
             if [[ $isCloudInitReady = false ]]; then
-              echo "waiting for entitlement check started..."
+              echo "waiting for entitlement/evaluation check started..."
               sleep 5
             else
-              echo "entitlement check started..."
+              echo "entitlement/evaluation check started..."
             fi
           done
 
@@ -255,10 +255,10 @@ jobs:
             result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} '(tail -n1) </var/log/cloud-init-was.log')
             # Remove special characters
             result=$(echo $result | sed $'s/[^[:alnum:]\t]//g')
-            if [[ "$result" == "Unentitled" ]] || [[ "$result" == "Entitled" ]] || [[ "$result" == "Undefined" ]]; then
+            if [[ "$result" == "Unentitled" ]] || [[ "$result" == "Entitled" ]] || [[ "$result" == "Undefined" ]] || [[ "$result" = "Evaluation" ]]; then
                 isDone=true
             else
-                echo "waiting for entitlement check completed..."
+                echo "waiting for entitlement/evaluation check completed..."
                 sleep 5
             fi
           done
@@ -271,6 +271,64 @@ jobs:
           # Check the installation path is removed
           echo "Check the installation path is removed"
           pathExists=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} 'if [ -d "${{ env.ihs_install_directory }}" ] && [ -d "${{ env.plugin_install_directory }}" ] && [ -d "${{ env.wct_install_directory }}" ]; then echo true; else echo false; fi')
+          if [[ $pathExists = false ]]; then
+            echo "IBM installations do not exist"
+            exit 1
+          fi
+      - name: Deploy VM using image for evaluation usage
+        run: |
+          imageResourceId=$(az image show --name ${{ env.vmName }} --resource-group ${{ env.testResourceGroup }} --query id -o tsv)
+          cd ${{ env.offerName }}/ihs/test
+          az deployment group create --resource-group ${{ env.testResourceGroup }} \
+              --name evaluation${{ github.run_id }}${{ github.run_number }} \
+              --template-file ./mainTemplate.json \
+              --parameters ibmUserId="" ibmUserPwd="" vmName=evaluation${{ github.run_id }}${{ github.run_number }} vmAdminId=${{ env.vmAdminId }} vmAdminPwd=${{ env.vmAdminPassword }} location=${{ env.location }} imageResourceId=$imageResourceId
+      - name: Verify the IBM installations for evaluation usage
+        run: |
+          echo "query public ip"
+          evaluationVMIP=$(az vm show \
+            --resource-group ${{ env.testResourceGroup }} \
+            --name evaluation${{ github.run_id }}${{ github.run_number }} -d \
+            --query publicIps -o tsv)
+          echo "pubilc IP of VM: ${evaluationVMIP}"
+          echo "Verifying WebSphere server installation"
+          echo install sshpass
+          sudo apt-get install -y sshpass
+          timeout 1m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${evaluationVMIP} 22
+          isCloudInitReady=false
+          while [ $isCloudInitReady = false ]
+          do
+            isCloudInitReady=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${evaluationVMIP} 'if [ ! -f "/var/log/cloud-init-was.log" ]; then echo false; else echo true; fi')
+            if [[ $isCloudInitReady = false ]]; then
+              echo "waiting for entitlement/evaluation check started..."
+              sleep 5
+            else
+              echo "entitlement/evaluation check started..."
+            fi
+          done
+
+          isDone=false
+          while [ $isDone = false ]
+          do
+            result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${evaluationVMIP} '(tail -n1) </var/log/cloud-init-was.log')
+            # Remove special characters
+            result=$(echo $result | sed $'s/[^[:alnum:]\t]//g')
+            if [[ "$result" == "Unentitled" ]] || [[ "$result" == "Entitled" ]] || [[ "$result" == "Undefined" ]] || [[ "$result" = "Evaluation" ]]; then
+                isDone=true
+            else
+                echo "waiting for entitlement/evaluation check completed..."
+                sleep 5
+            fi
+          done
+          echo $result
+
+          if [ ${result} != Evaluation ]; then
+              exit 1
+          fi
+          
+          # Check the installation path exists
+          echo "Check the installation path exists"
+          pathExists=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${evaluationVMIP} 'if [ -d "${{ env.ihs_install_directory }}" ] && [ -d "${{ env.plugin_install_directory }}" ] && [ -d "${{ env.wct_install_directory }}" ]; then echo true; else echo false; fi')
           if [[ $pathExists = false ]]; then
             echo "IBM installations do not exist"
             exit 1
@@ -324,10 +382,16 @@ jobs:
             echo "unentitledDataDiskIds: ${unentitledDataDiskIds}"
 
             entitledOsDiskId=$(az vm show --resource-group ${{ env.testResourceGroup }} --name entitled${{ github.run_id }}${{ github.run_number }} --query "storageProfile.osDisk.managedDisk.id" -o tsv)
-            echo "unentitledOsDiskId: ${unentitledOsDiskId}"
+            echo "entitledOsDiskId: ${entitledOsDiskId}"
 
             entitledDataDiskIds=$(az vm show --resource-group ${{ env.testResourceGroup }} --name entitled${{ github.run_id }}${{ github.run_number }} --query "storageProfile.dataDisks" | jq -r 'map(.managedDisk.id) | join(" ")')
-            echo "unentitledDataDiskIds: ${unentitledDataDiskIds}"
+            echo "entitledDataDiskIds: ${entitledDataDiskIds}"
+
+            evaluationOsDiskId=$(az vm show --resource-group ${{ env.testResourceGroup }} --name evaluation${{ github.run_id }}${{ github.run_number }} --query "storageProfile.osDisk.managedDisk.id" -o tsv)
+            echo "evaluationOsDiskId: ${evaluationOsDiskId}"
+
+            evaluationDataDiskIds=$(az vm show --resource-group ${{ env.testResourceGroup }} --name evaluation${{ github.run_id }}${{ github.run_number }} --query "storageProfile.dataDisks" | jq -r 'map(.managedDisk.id) | join(" ")')
+            echo "evaluationDataDiskIds: ${evaluationDataDiskIds}"
 
             vmForImage=$(az vm list --resource-group ${{ env.testResourceGroup }} --query "[?name=='${{ env.vmName }}']" | jq -r 'map(.id) | join(" ")')
             echo $vmForImage
@@ -337,7 +401,7 @@ jobs:
 
             az vm delete --verbose --ids $vmForImage --yes
             az resource delete --verbose --ids $resourcesToDelete
-            az disk delete --yes --resource-group ${{ env.testResourceGroup }} --ids ${unentitledOsDiskId} ${unentitledDataDiskIds} ${entitledOsDiskId} ${entitledDataDiskIds}
+            az disk delete --yes --resource-group ${{ env.testResourceGroup }} --ids ${unentitledOsDiskId} ${unentitledDataDiskIds} ${entitledOsDiskId} ${entitledDataDiskIds} ${evaluationOsDiskId} ${evaluationDataDiskIds}
   summary:
     needs: build
     if: always()

--- a/.github/workflows/twas-baseBuild.yml
+++ b/.github/workflows/twas-baseBuild.yml
@@ -410,7 +410,7 @@ jobs:
       - name: summarize jobs
         if: always()
         run: |
-            workflow_jobs=$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/WASdev/azure.websphere-traditional.image/actions/runs/${{ github.run_id }}/jobs)
+            workflow_jobs=$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${{ env.userName }}/azure.websphere-traditional.image/actions/runs/${{ github.run_id }}/jobs)
 
             success_build_job=$(echo $workflow_jobs | jq '.jobs | map(select(.name=="build" and .conclusion=="success")) | length')
             echo "$success_build_job"
@@ -422,7 +422,7 @@ jobs:
                 {
                 "@context":"http://schema.org/extensions",
                 "@type":"MessageCard",
-                "text":"Workflow of repo 'azure.websphere-traditional.image/twas-base' failed, please take a look at: https://github.com/WASdev/azure.websphere-traditional.image/actions/runs/${{ github.run_id }}"
+                "text":"Workflow of repo 'azure.websphere-traditional.image/twas-base' failed, please take a look at: https://github.com/${{ env.userName }}/azure.websphere-traditional.image/actions/runs/${{ github.run_id }}"
                 }
             EOF
             else

--- a/.github/workflows/twas-baseBuild.yml
+++ b/.github/workflows/twas-baseBuild.yml
@@ -179,10 +179,10 @@ jobs:
           do
             isCloudInitReady=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${untitledVMIP} 'if [ ! -f "/var/log/cloud-init-was.log" ]; then echo false; else echo true; fi')
             if [[ $isCloudInitReady = false ]]; then
-              echo "waiting for was entitlement check started..."
+              echo "waiting for was entitlement/evaluation check started..."
               sleep 5
             else
-              echo "was entitlement check started..."
+              echo "was entitlement/evaluation check started..."
             fi
           done
 
@@ -192,10 +192,10 @@ jobs:
             result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${untitledVMIP} '(tail -n1) </var/log/cloud-init-was.log')
             # Remove special characters
             result=$(echo $result | sed $'s/[^[:alnum:]\t]//g')
-            if [[ "$result" == "Unentitled" ]] || [[ "$result" == "Entitled" ]] || [[ "$result" == "Undefined" ]]; then
+            if [[ "$result" == "Unentitled" ]] || [[ "$result" == "Entitled" ]] || [[ "$result" == "Undefined" ]] || [[ "$result" = "Evaluation" ]]; then
                 isDone=true
             else
-                echo "waiting for was entitlement check completed..."
+                echo "waiting for was entitlement/evaluation check completed..."
                 sleep 5
             fi
           done
@@ -238,10 +238,10 @@ jobs:
           do
             isCloudInitReady=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} 'if [ ! -f "/var/log/cloud-init-was.log" ]; then echo false; else echo true; fi')
             if [[ $isCloudInitReady = false ]]; then
-              echo "waiting for was entitlement check started..."
+              echo "waiting for was entitlement/evaluation check started..."
               sleep 5
             else
-              echo "was entitlement check started..."
+              echo "was entitlement/evaluation check started..."
             fi
           done
 
@@ -251,10 +251,10 @@ jobs:
             result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} '(tail -n1) </var/log/cloud-init-was.log')
             # Remove special characters
             result=$(echo $result | sed $'s/[^[:alnum:]\t]//g')
-            if [[ "$result" == "Unentitled" ]] || [[ "$result" == "Entitled" ]] || [[ "$result" == "Undefined" ]]; then
+            if [[ "$result" == "Unentitled" ]] || [[ "$result" == "Entitled" ]] || [[ "$result" == "Undefined" ]] || [[ "$result" = "Evaluation" ]]; then
                 isDone=true
             else
-                echo "waiting for was entitlement check completed..."
+                echo "waiting for was entitlement/evaluation check completed..."
                 sleep 5
             fi
           done
@@ -267,6 +267,64 @@ jobs:
           # Check the installation path is removed
           echo "Check the installation path is removed"
           pathExists=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} 'if [ -d "${{ env.was_base_install_directory }}" ]; then echo true; else echo false; fi')
+          if [[ $pathExists = false ]]; then
+            echo "IBM installations do not exist"
+            exit 1
+          fi
+      - name: Deploy VM using image for evaluation usage
+        run: |
+          imageResourceId=$(az image show --name ${{ env.vmName }} --resource-group ${{ env.testResourceGroup }} --query id -o tsv)
+          cd ${{ env.offerName }}/twas-base/test
+          az deployment group create --resource-group ${{ env.testResourceGroup }} \
+              --name evaluation${{ github.run_id }}${{ github.run_number }} \
+              --template-file ./mainTemplate.json \
+              --parameters ibmUserId="" ibmUserPwd="" vmName=evaluation${{ github.run_id }}${{ github.run_number }} vmAdminId=${{ env.vmAdminId }} vmAdminPwd=${{ env.vmAdminPassword }} location=${{ env.location }} imageResourceId=$imageResourceId
+      - name: Verify the IBM installations for evaluation usage
+        run: |
+          echo "query public ip"
+          evaluationVMIP=$(az vm show \
+            --resource-group ${{ env.testResourceGroup }} \
+            --name evaluation${{ github.run_id }}${{ github.run_number }} -d \
+            --query publicIps -o tsv)
+          echo "pubilc IP of VM: ${evaluationVMIP}"
+          echo "Verifying WebSphere server installation"
+          echo install sshpass
+          sudo apt-get install -y sshpass
+          timeout 1m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${evaluationVMIP} 22
+          isCloudInitReady=false
+          while [ $isCloudInitReady = false ]
+          do
+            isCloudInitReady=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${evaluationVMIP} 'if [ ! -f "/var/log/cloud-init-was.log" ]; then echo false; else echo true; fi')
+            if [[ $isCloudInitReady = false ]]; then
+              echo "waiting for entitlement/evaluation check started..."
+              sleep 5
+            else
+              echo "entitlement/evaluation check started..."
+            fi
+          done
+
+          isDone=false
+          while [ $isDone = false ]
+          do
+            result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${evaluationVMIP} '(tail -n1) </var/log/cloud-init-was.log')
+            # Remove special characters
+            result=$(echo $result | sed $'s/[^[:alnum:]\t]//g')
+            if [[ "$result" == "Unentitled" ]] || [[ "$result" == "Entitled" ]] || [[ "$result" == "Undefined" ]] || [[ "$result" = "Evaluation" ]]; then
+                isDone=true
+            else
+                echo "waiting for entitlement/evaluation check completed..."
+                sleep 5
+            fi
+          done
+          echo $result
+
+          if [ ${result} != Evaluation ]; then
+              exit 1
+          fi
+          
+          # Check the installation path exists
+          echo "Check the installation path exists"
+          pathExists=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${evaluationVMIP} 'if [ -d "${{ env.was_base_install_directory }}" ]; then echo true; else echo false; fi')
           if [[ $pathExists = false ]]; then
             echo "IBM installations do not exist"
             exit 1
@@ -320,10 +378,16 @@ jobs:
             echo "unentitledDataDiskIds: ${unentitledDataDiskIds}"
 
             entitledOsDiskId=$(az vm show --resource-group ${{ env.testResourceGroup }} --name entitled${{ github.run_id }}${{ github.run_number }} --query "storageProfile.osDisk.managedDisk.id" -o tsv)
-            echo "unentitledOsDiskId: ${unentitledOsDiskId}"
+            echo "entitledOsDiskId: ${entitledOsDiskId}"
 
             entitledDataDiskIds=$(az vm show --resource-group ${{ env.testResourceGroup }} --name entitled${{ github.run_id }}${{ github.run_number }} --query "storageProfile.dataDisks" | jq -r 'map(.managedDisk.id) | join(" ")')
-            echo "unentitledDataDiskIds: ${unentitledDataDiskIds}"
+            echo "entitledDataDiskIds: ${entitledDataDiskIds}"
+
+            evaluationOsDiskId=$(az vm show --resource-group ${{ env.testResourceGroup }} --name evaluation${{ github.run_id }}${{ github.run_number }} --query "storageProfile.osDisk.managedDisk.id" -o tsv)
+            echo "evaluationOsDiskId: ${evaluationOsDiskId}"
+
+            evaluationDataDiskIds=$(az vm show --resource-group ${{ env.testResourceGroup }} --name evaluation${{ github.run_id }}${{ github.run_number }} --query "storageProfile.dataDisks" | jq -r 'map(.managedDisk.id) | join(" ")')
+            echo "evaluationDataDiskIds: ${evaluationDataDiskIds}"
 
             vmForImage=$(az vm list --resource-group ${{ env.testResourceGroup }} --query "[?name=='${{ env.vmName }}']" | jq -r 'map(.id) | join(" ")')
             echo $vmForImage
@@ -333,7 +397,7 @@ jobs:
 
             az vm delete --verbose --ids $vmForImage --yes
             az resource delete --verbose --ids $resourcesToDelete
-            az disk delete --yes --resource-group ${{ env.testResourceGroup }} --ids ${unentitledOsDiskId} ${unentitledDataDiskIds} ${entitledOsDiskId} ${entitledDataDiskIds}
+            az disk delete --yes --resource-group ${{ env.testResourceGroup }} --ids ${unentitledOsDiskId} ${unentitledDataDiskIds} ${entitledOsDiskId} ${entitledDataDiskIds} ${evaluationOsDiskId} ${evaluationDataDiskIds}
   summary:
     needs: build
     if: always()

--- a/.github/workflows/twas-ndBuild.yml
+++ b/.github/workflows/twas-ndBuild.yml
@@ -412,7 +412,7 @@ jobs:
       - name: summarize jobs
         if: always()
         run: |
-            workflow_jobs=$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/WASdev/azure.websphere-traditional.image/actions/runs/${{ github.run_id }}/jobs)
+            workflow_jobs=$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${{ env.userName }}/azure.websphere-traditional.image/actions/runs/${{ github.run_id }}/jobs)
 
             success_build_job=$(echo $workflow_jobs | jq '.jobs | map(select(.name=="build" and .conclusion=="success")) | length')
             echo "$success_build_job"
@@ -424,7 +424,7 @@ jobs:
                 {
                 "@context":"http://schema.org/extensions",
                 "@type":"MessageCard",
-                "text":"Workflow of repo 'azure.websphere-traditional.image/twas-nd' failed, please take a look at: https://github.com/WASdev/azure.websphere-traditional.image/actions/runs/${{ github.run_id }}"
+                "text":"Workflow of repo 'azure.websphere-traditional.image/twas-nd' failed, please take a look at: https://github.com/${{ env.userName }}/azure.websphere-traditional.image/actions/runs/${{ github.run_id }}"
                 }
             EOF
             else

--- a/.github/workflows/twas-ndBuild.yml
+++ b/.github/workflows/twas-ndBuild.yml
@@ -181,10 +181,10 @@ jobs:
           do
             isCloudInitReady=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${untitledVMIP} 'if [ ! -f "/var/log/cloud-init-was.log" ]; then echo false; else echo true; fi')
             if [[ $isCloudInitReady = false ]]; then
-              echo "waiting for was entitlement check started..."
+              echo "waiting for was entitlement/evaluation check started..."
               sleep 5
             else
-              echo "was entitlement check started..."
+              echo "was entitlement/evaluation check started..."
             fi
           done
 
@@ -194,10 +194,10 @@ jobs:
             result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${untitledVMIP} '(tail -n1) </var/log/cloud-init-was.log')
             # Remove special characters
             result=$(echo $result | sed $'s/[^[:alnum:]\t]//g')
-            if [[ "$result" == "Unentitled" ]] || [[ "$result" == "Entitled" ]] || [[ "$result" == "Undefined" ]]; then
+            if [[ "$result" == "Unentitled" ]] || [[ "$result" == "Entitled" ]] || [[ "$result" == "Undefined" ]] || [[ "$result" = "Evaluation" ]]; then
                 isDone=true
             else
-                echo "waiting for was entitlement check completed..."
+                echo "waiting for was entitlement/evaluation check completed..."
                 sleep 5
             fi
           done
@@ -240,10 +240,10 @@ jobs:
           do
             isCloudInitReady=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} 'if [ ! -f "/var/log/cloud-init-was.log" ]; then echo false; else echo true; fi')
             if [[ $isCloudInitReady = false ]]; then
-              echo "waiting for was entitlement check started..."
+              echo "waiting for was entitlement/evaluation check started..."
               sleep 5
             else
-              echo "was entitlement check started..."
+              echo "was entitlement/evaluation check started..."
             fi
           done
 
@@ -253,10 +253,10 @@ jobs:
             result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} '(tail -n1) </var/log/cloud-init-was.log')
             # Remove special characters
             result=$(echo $result | sed $'s/[^[:alnum:]\t]//g')
-            if [[ "$result" == "Unentitled" ]] || [[ "$result" == "Entitled" ]] || [[ "$result" == "Undefined" ]]; then
+            if [[ "$result" == "Unentitled" ]] || [[ "$result" == "Entitled" ]] || [[ "$result" == "Undefined" ]] || [[ "$result" = "Evaluation" ]]; then
                 isDone=true
             else
-                echo "waiting for was entitlement check completed..."
+                echo "waiting for was entitlement/evaluation check completed..."
                 sleep 5
             fi
           done
@@ -269,6 +269,64 @@ jobs:
           # Check the installation path is removed
           echo "Check the installation path is removed"
           pathExists=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} 'if [ -d "${{ env.was_nd_install_directory }}" ]; then echo true; else echo false; fi')
+          if [[ $pathExists = false ]]; then
+            echo "IBM installations do not exist"
+            exit 1
+          fi
+      - name: Deploy VM using image for evaluation usage
+        run: |
+          imageResourceId=$(az image show --name ${{ env.vmName }} --resource-group ${{ env.testResourceGroup }} --query id -o tsv)
+          cd ${{ env.offerName }}/twas-nd/test
+          az deployment group create --resource-group ${{ env.testResourceGroup }} \
+              --name evaluation${{ github.run_id }}${{ github.run_number }} \
+              --template-file ./mainTemplate.json \
+              --parameters ibmUserId="" ibmUserPwd="" vmName=evaluation${{ github.run_id }}${{ github.run_number }} vmAdminId=${{ env.vmAdminId }} vmAdminPwd=${{ env.vmAdminPassword }} location=${{ env.location }} imageResourceId=$imageResourceId
+      - name: Verify the IBM installations for evaluation usage
+        run: |
+          echo "query public ip"
+          evaluationVMIP=$(az vm show \
+            --resource-group ${{ env.testResourceGroup }} \
+            --name evaluation${{ github.run_id }}${{ github.run_number }} -d \
+            --query publicIps -o tsv)
+          echo "pubilc IP of VM: ${evaluationVMIP}"
+          echo "Verifying WebSphere server installation"
+          echo install sshpass
+          sudo apt-get install -y sshpass
+          timeout 1m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${evaluationVMIP} 22
+          isCloudInitReady=false
+          while [ $isCloudInitReady = false ]
+          do
+            isCloudInitReady=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${evaluationVMIP} 'if [ ! -f "/var/log/cloud-init-was.log" ]; then echo false; else echo true; fi')
+            if [[ $isCloudInitReady = false ]]; then
+              echo "waiting for entitlement/evaluation check started..."
+              sleep 5
+            else
+              echo "entitlement/evaluation check started..."
+            fi
+          done
+
+          isDone=false
+          while [ $isDone = false ]
+          do
+            result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${evaluationVMIP} '(tail -n1) </var/log/cloud-init-was.log')
+            # Remove special characters
+            result=$(echo $result | sed $'s/[^[:alnum:]\t]//g')
+            if [[ "$result" == "Unentitled" ]] || [[ "$result" == "Entitled" ]] || [[ "$result" == "Undefined" ]] || [[ "$result" = "Evaluation" ]]; then
+                isDone=true
+            else
+                echo "waiting for entitlement/evaluation check completed..."
+                sleep 5
+            fi
+          done
+          echo $result
+
+          if [ ${result} != Evaluation ]; then
+              exit 1
+          fi
+          
+          # Check the installation path exists
+          echo "Check the installation path exists"
+          pathExists=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${evaluationVMIP} 'if [ -d "${{ env.was_nd_install_directory }}" ]; then echo true; else echo false; fi')
           if [[ $pathExists = false ]]; then
             echo "IBM installations do not exist"
             exit 1
@@ -322,10 +380,16 @@ jobs:
             echo "unentitledDataDiskIds: ${unentitledDataDiskIds}"
 
             entitledOsDiskId=$(az vm show --resource-group ${{ env.testResourceGroup }} --name entitled${{ github.run_id }}${{ github.run_number }} --query "storageProfile.osDisk.managedDisk.id" -o tsv)
-            echo "unentitledOsDiskId: ${unentitledOsDiskId}"
+            echo "entitledOsDiskId: ${entitledOsDiskId}"
 
             entitledDataDiskIds=$(az vm show --resource-group ${{ env.testResourceGroup }} --name entitled${{ github.run_id }}${{ github.run_number }} --query "storageProfile.dataDisks" | jq -r 'map(.managedDisk.id) | join(" ")')
-            echo "unentitledDataDiskIds: ${unentitledDataDiskIds}"
+            echo "entitledDataDiskIds: ${entitledDataDiskIds}"
+
+            evaluationOsDiskId=$(az vm show --resource-group ${{ env.testResourceGroup }} --name evaluation${{ github.run_id }}${{ github.run_number }} --query "storageProfile.osDisk.managedDisk.id" -o tsv)
+            echo "evaluationOsDiskId: ${evaluationOsDiskId}"
+
+            evaluationDataDiskIds=$(az vm show --resource-group ${{ env.testResourceGroup }} --name evaluation${{ github.run_id }}${{ github.run_number }} --query "storageProfile.dataDisks" | jq -r 'map(.managedDisk.id) | join(" ")')
+            echo "evaluationDataDiskIds: ${evaluationDataDiskIds}"
 
             vmForImage=$(az vm list --resource-group ${{ env.testResourceGroup }} --query "[?name=='${{ env.vmName }}']" | jq -r 'map(.id) | join(" ")')
             echo $vmForImage
@@ -335,7 +399,7 @@ jobs:
 
             az vm delete --verbose --ids $vmForImage --yes
             az resource delete --verbose --ids $resourcesToDelete
-            az disk delete --yes --resource-group ${{ env.testResourceGroup }} --ids ${unentitledOsDiskId} ${unentitledDataDiskIds} ${entitledOsDiskId} ${entitledDataDiskIds}
+            az disk delete --yes --resource-group ${{ env.testResourceGroup }} --ids ${unentitledOsDiskId} ${unentitledDataDiskIds} ${entitledOsDiskId} ${entitledDataDiskIds} ${evaluationOsDiskId} ${evaluationDataDiskIds}
   summary:
     needs: build
     if: always()

--- a/README.md
+++ b/README.md
@@ -2,4 +2,5 @@
 # [Deploy an Azure VM with RHEL 8.4, IBM WebSphere Application Server Traditional V9.0.5 & IBM JDK 8.0 pre-installed](/twas-base)
 # [Deploy an Azure VM with RHEL 8.4, IBM WebSphere Application Server ND Traditional V9.0.5 & IBM JDK 8.0 pre-installed](/twas-nd)
 # [Related: Deploy RHEL 8.4 VMs on Azure with IBM WebSphere Application Server ND Traditional V9.0.5 cluster pre-installed](https://github.com/WASdev/azure.websphere-traditional.cluster)
+# [Related: Deploy RHEL 8.4 VM on Azure with IBM WebSphere Application Server traditional V9.0.5 single server pre-installed](https://github.com/WASdev/azure.websphere-traditional.singleserver)
 # [Issues](https://github.com/WASdev/azure.websphere-traditional.cluster/issues)

--- a/ihs/src/main/scripts/virtualimage.properties
+++ b/ihs/src/main/scripts/virtualimage.properties
@@ -32,3 +32,4 @@ WAS_LOG_PATH=/var/log/cloud-init-was.log
 UNENTITLED=Unentitled
 ENTITLED=Entitled
 UNDEFINED=Undefined
+EVALUATION=Evaluation

--- a/ihs/src/main/scripts/was-check.sh
+++ b/ihs/src/main/scripts/was-check.sh
@@ -26,7 +26,7 @@ read -r -a ibmIdCredentials <<< "$(echo $customData | base64 -d)"
 # Check whether IBMid is entitled or not, or user is trying to use an evaluation edition
 result=$UNENTITLED
 if [ ${#ibmIdCredentials[@]} -eq 2 ]; then
-    echo "$(date): Start to check entitlement." > $WAS_LOG_PATH
+    echo "$(date): Start to check entitlement." >> $WAS_LOG_PATH
     
     userName=${ibmIdCredentials[0]}
     password=${ibmIdCredentials[1]}

--- a/ihs/src/main/scripts/was-check.sh
+++ b/ihs/src/main/scripts/was-check.sh
@@ -17,15 +17,17 @@
 # Get tWAS installation properties
 source /datadrive/virtualimage.properties
 
-echo "$(date): Start to check entitlement." > $WAS_LOG_PATH
+echo "$(date): Start to check IBMid." > $WAS_LOG_PATH
 
 # Read custom data from ovf-env.xml
 customData=`xmllint --xpath "//*[local-name()='Environment']/*[local-name()='ProvisioningSection']/*[local-name()='LinuxProvisioningConfigurationSet']/*[local-name()='CustomData']/text()" /var/lib/waagent/ovf-env.xml`
 read -r -a ibmIdCredentials <<< "$(echo $customData | base64 -d)"
 
-# Check whether IBMid is entitled or not
+# Check whether IBMid is entitled or not, or user is trying to use an evaluation edition
 result=$UNENTITLED
 if [ ${#ibmIdCredentials[@]} -eq 2 ]; then
+    echo "$(date): Start to check entitlement." > $WAS_LOG_PATH
+    
     userName=${ibmIdCredentials[0]}
     password=${ibmIdCredentials[1]}
     
@@ -38,27 +40,30 @@ if [ ${#ibmIdCredentials[@]} -eq 2 ]; then
     output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl listAvailablePackages -cPA -secureStorageFile storage_file)
     echo $output | grep -q "$WAS_ND_VERSION_ENTITLED" && result=$ENTITLED
     echo $output | grep -q "$NO_PACKAGES_FOUND" && result=$UNDEFINED
+
+    echo "$(date): Entitlement check completed, start to update WebSphere installation." >> $WAS_LOG_PATH
+    if [ ${result} = $ENTITLED ]; then
+        # Update all packages for the entitled user
+        output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl updateAll -repositories "$REPOSITORY_URL" \
+            -acceptLicense -log log_file -installFixes recommended -secureStorageFile storage_file -preferences $SSL_PREF,$DOWNLOAD_PREF -showProgress)
+        echo "$output" >> $WAS_LOG_PATH
+    else
+        # Remove installations for the un-entitled or undefined user
+        output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl uninstall "$IBM_HTTP_SERVER" "$IBM_JAVA_SDK" -installationDirectory ${IHS_INSTALL_DIRECTORY})
+        echo "$output" >> $WAS_LOG_PATH
+        output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl uninstall "$WEBSPHERE_PLUGIN" "$IBM_JAVA_SDK" -installationDirectory ${PLUGIN_INSTALL_DIRECTORY})
+        echo "$output" >> $WAS_LOG_PATH
+        output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl uninstall "$WEBSPHERE_WCT" "$IBM_JAVA_SDK" -installationDirectory ${WCT_INSTALL_DIRECTORY})
+        echo "$output" >> $WAS_LOG_PATH
+        rm -rf /datadrive/IBM && rm -rf /datadrive/virtualimage.properties
+    fi
+    echo "$(date): WebSphere installation updated." >> $WAS_LOG_PATH
 else
-    echo "Invalid input format." >> $WAS_LOG_PATH
+    # invalid format of the input will be recognized as evaluation usage
+    result=$EVALUATION
+    echo "$(date): Evaluation usage is selected, neither the entitlement check nor the iFixes will be applied." >> $WAS_LOG_PATH
 fi
 
-echo "$(date): Entitlement check completed, start to update WebSphere installation." >> $WAS_LOG_PATH
-if [ ${result} = $ENTITLED ]; then
-    # Update all packages for the entitled user
-    output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl updateAll -repositories "$REPOSITORY_URL" \
-        -acceptLicense -log log_file -installFixes recommended -secureStorageFile storage_file -preferences $SSL_PREF,$DOWNLOAD_PREF -showProgress)
-    echo "$output" >> $WAS_LOG_PATH
-else
-    # Remove installations for the un-entitled or undefined user
-    output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl uninstall "$IBM_HTTP_SERVER" "$IBM_JAVA_SDK" -installationDirectory ${IHS_INSTALL_DIRECTORY})
-    echo "$output" >> $WAS_LOG_PATH
-    output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl uninstall "$WEBSPHERE_PLUGIN" "$IBM_JAVA_SDK" -installationDirectory ${PLUGIN_INSTALL_DIRECTORY})
-    echo "$output" >> $WAS_LOG_PATH
-    output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl uninstall "$WEBSPHERE_WCT" "$IBM_JAVA_SDK" -installationDirectory ${WCT_INSTALL_DIRECTORY})
-    echo "$output" >> $WAS_LOG_PATH
-    rm -rf /datadrive/IBM && rm -rf /datadrive/virtualimage.properties
-fi
-echo "$(date): WebSphere installation updated." >> $WAS_LOG_PATH
 echo ${result} >> $WAS_LOG_PATH
 
 # Scrub the custom data from files which contain sensitive information

--- a/twas-base/src/main/scripts/virtualimage.properties
+++ b/twas-base/src/main/scripts/virtualimage.properties
@@ -27,3 +27,4 @@ WAS_LOG_PATH=/var/log/cloud-init-was.log
 UNENTITLED=Unentitled
 ENTITLED=Entitled
 UNDEFINED=Undefined
+EVALUATION=Evaluation

--- a/twas-base/src/main/scripts/was-check.sh
+++ b/twas-base/src/main/scripts/was-check.sh
@@ -17,15 +17,17 @@
 # Get tWAS installation properties
 source /datadrive/virtualimage.properties
 
-echo "$(date): Start to check entitlement." > $WAS_LOG_PATH
+echo "$(date): Start to check IBMid." > $WAS_LOG_PATH
 
 # Read custom data from ovf-env.xml
 customData=`xmllint --xpath "//*[local-name()='Environment']/*[local-name()='ProvisioningSection']/*[local-name()='LinuxProvisioningConfigurationSet']/*[local-name()='CustomData']/text()" /var/lib/waagent/ovf-env.xml`
 read -r -a ibmIdCredentials <<< "$(echo $customData | base64 -d)"
 
-# Check whether IBMid is entitled or not
+# Check whether IBMid is entitled or not, or user is trying to use an evaluation edition
 result=$UNENTITLED
 if [ ${#ibmIdCredentials[@]} -eq 2 ]; then
+    echo "$(date): Start to check entitlement." > $WAS_LOG_PATH
+
     userName=${ibmIdCredentials[0]}
     password=${ibmIdCredentials[1]}
     
@@ -38,23 +40,26 @@ if [ ${#ibmIdCredentials[@]} -eq 2 ]; then
     output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl listAvailablePackages -cPA -secureStorageFile storage_file)
     echo $output | grep -q "$WAS_BASE_VERSION_ENTITLED" && result=$ENTITLED
     echo $output | grep -q "$NO_PACKAGES_FOUND" && result=$UNDEFINED
+
+    echo "$(date): Entitlement check completed, start to update WebSphere installation." >> $WAS_LOG_PATH
+    if [ ${result} = $ENTITLED ]; then
+        # Update all packages for the entitled user
+        output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl updateAll -repositories "$REPOSITORY_URL" \
+            -acceptLicense -log log_file -installFixes recommended -secureStorageFile storage_file -preferences $SSL_PREF,$DOWNLOAD_PREF -showProgress)
+        echo "$output" >> $WAS_LOG_PATH
+    else
+        # Remove tWAS installation for the un-entitled or undefined user
+        output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl uninstall "$WAS_BASE_TRADITIONAL" "$IBM_JAVA_SDK" -installationDirectory ${WAS_BASE_INSTALL_DIRECTORY})
+        echo "$output" >> $WAS_LOG_PATH
+        rm -rf /datadrive/IBM && rm -rf /datadrive/virtualimage.properties
+    fi
+    echo "$(date): WebSphere installation updated." >> $WAS_LOG_PATH
 else
-    echo "Invalid input format." >> $WAS_LOG_PATH
+    # invalid format of the input will be recognized as evaluation usage
+    result=$EVALUATION
+    echo "$(date): Evaluation usage is selected, neither the entitlement check nor the iFixes will be applied." >> $WAS_LOG_PATH
 fi
 
-echo "$(date): Entitlement check completed, start to update WebSphere installation." >> $WAS_LOG_PATH
-if [ ${result} = $ENTITLED ]; then
-    # Update all packages for the entitled user
-    output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl updateAll -repositories "$REPOSITORY_URL" \
-        -acceptLicense -log log_file -installFixes recommended -secureStorageFile storage_file -preferences $SSL_PREF,$DOWNLOAD_PREF -showProgress)
-    echo "$output" >> $WAS_LOG_PATH
-else
-    # Remove tWAS installation for the un-entitled or undefined user
-    output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl uninstall "$WAS_BASE_TRADITIONAL" "$IBM_JAVA_SDK" -installationDirectory ${WAS_BASE_INSTALL_DIRECTORY})
-    echo "$output" >> $WAS_LOG_PATH
-    rm -rf /datadrive/IBM && rm -rf /datadrive/virtualimage.properties
-fi
-echo "$(date): WebSphere installation updated." >> $WAS_LOG_PATH
 echo ${result} >> $WAS_LOG_PATH
 
 # Scrub the custom data from files which contain sensitive information

--- a/twas-base/src/main/scripts/was-check.sh
+++ b/twas-base/src/main/scripts/was-check.sh
@@ -26,7 +26,7 @@ read -r -a ibmIdCredentials <<< "$(echo $customData | base64 -d)"
 # Check whether IBMid is entitled or not, or user is trying to use an evaluation edition
 result=$UNENTITLED
 if [ ${#ibmIdCredentials[@]} -eq 2 ]; then
-    echo "$(date): Start to check entitlement." > $WAS_LOG_PATH
+    echo "$(date): Start to check entitlement." >> $WAS_LOG_PATH
 
     userName=${ibmIdCredentials[0]}
     password=${ibmIdCredentials[1]}

--- a/twas-nd/src/main/scripts/virtualimage.properties
+++ b/twas-nd/src/main/scripts/virtualimage.properties
@@ -27,3 +27,4 @@ WAS_LOG_PATH=/var/log/cloud-init-was.log
 UNENTITLED=Unentitled
 ENTITLED=Entitled
 UNDEFINED=Undefined
+EVALUATION=Evaluation

--- a/twas-nd/src/main/scripts/was-check.sh
+++ b/twas-nd/src/main/scripts/was-check.sh
@@ -17,15 +17,17 @@
 # Get tWAS installation properties
 source /datadrive/virtualimage.properties
 
-echo "$(date): Start to check entitlement." > $WAS_LOG_PATH
+echo "$(date): Start to check IBMid." > $WAS_LOG_PATH
 
 # Read custom data from ovf-env.xml
 customData=`xmllint --xpath "//*[local-name()='Environment']/*[local-name()='ProvisioningSection']/*[local-name()='LinuxProvisioningConfigurationSet']/*[local-name()='CustomData']/text()" /var/lib/waagent/ovf-env.xml`
 read -r -a ibmIdCredentials <<< "$(echo $customData | base64 -d)"
 
-# Check whether IBMid is entitled or not
+# Check whether IBMid is entitled or not, or user is trying to use an evaluation edition
 result=$UNENTITLED
 if [ ${#ibmIdCredentials[@]} -eq 2 ]; then
+    echo "$(date): Start to check entitlement." > $WAS_LOG_PATH
+
     userName=${ibmIdCredentials[0]}
     password=${ibmIdCredentials[1]}
     
@@ -38,23 +40,26 @@ if [ ${#ibmIdCredentials[@]} -eq 2 ]; then
     output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl listAvailablePackages -cPA -secureStorageFile storage_file)
     echo $output | grep -q "$WAS_ND_VERSION_ENTITLED" && result=$ENTITLED
     echo $output | grep -q "$NO_PACKAGES_FOUND" && result=$UNDEFINED
+
+    echo "$(date): Entitlement check completed, start to update WebSphere installation." >> $WAS_LOG_PATH
+    if [ ${result} = $ENTITLED ]; then
+        # Update all packages for the entitled user
+        output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl updateAll -repositories "$REPOSITORY_URL" \
+            -acceptLicense -log log_file -installFixes recommended -secureStorageFile storage_file -preferences $SSL_PREF,$DOWNLOAD_PREF -showProgress)
+        echo "$output" >> $WAS_LOG_PATH
+    else
+        # Remove tWAS installation for the un-entitled or undefined user
+        output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl uninstall "$WAS_ND_TRADITIONAL" "$IBM_JAVA_SDK" -installationDirectory ${WAS_ND_INSTALL_DIRECTORY})
+        echo "$output" >> $WAS_LOG_PATH
+        rm -rf /datadrive/IBM && rm -rf /datadrive/virtualimage.properties
+    fi
+    echo "$(date): WebSphere installation updated." >> $WAS_LOG_PATH
 else
-    echo "Invalid input format." >> $WAS_LOG_PATH
+    # invalid format of the input will be recognized as evaluation usage
+    result=$EVALUATION
+    echo "$(date): Evaluation usage is selected, neither the entitlement check nor the iFixes will be applied." >> $WAS_LOG_PATH
 fi
 
-echo "$(date): Entitlement check completed, start to update WebSphere installation." >> $WAS_LOG_PATH
-if [ ${result} = $ENTITLED ]; then
-    # Update all packages for the entitled user
-    output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl updateAll -repositories "$REPOSITORY_URL" \
-        -acceptLicense -log log_file -installFixes recommended -secureStorageFile storage_file -preferences $SSL_PREF,$DOWNLOAD_PREF -showProgress)
-    echo "$output" >> $WAS_LOG_PATH
-else
-    # Remove tWAS installation for the un-entitled or undefined user
-    output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl uninstall "$WAS_ND_TRADITIONAL" "$IBM_JAVA_SDK" -installationDirectory ${WAS_ND_INSTALL_DIRECTORY})
-    echo "$output" >> $WAS_LOG_PATH
-    rm -rf /datadrive/IBM && rm -rf /datadrive/virtualimage.properties
-fi
-echo "$(date): WebSphere installation updated." >> $WAS_LOG_PATH
 echo ${result} >> $WAS_LOG_PATH
 
 # Scrub the custom data from files which contain sensitive information

--- a/twas-nd/src/main/scripts/was-check.sh
+++ b/twas-nd/src/main/scripts/was-check.sh
@@ -26,7 +26,7 @@ read -r -a ibmIdCredentials <<< "$(echo $customData | base64 -d)"
 # Check whether IBMid is entitled or not, or user is trying to use an evaluation edition
 result=$UNENTITLED
 if [ ${#ibmIdCredentials[@]} -eq 2 ]; then
-    echo "$(date): Start to check entitlement." > $WAS_LOG_PATH
+    echo "$(date): Start to check entitlement." >> $WAS_LOG_PATH
 
     userName=${ibmIdCredentials[0]}
     password=${ibmIdCredentials[1]}


### PR DESCRIPTION
## Description

The PR is to resolve WASdev/azure.websphere-traditional.cluster/issues/144 by changing the base image to support both entitlement and evaluation usages:
- If `customData` (input of `cloud-init`) has an valid format of IBMid credential, do entitlement check and iFixes installation as before.
- Otherwise it will be recognized as evaluation usage, neither the entitlement check nor the iFixes will be applied.

The pipeline is also enhanced to test evaluation feature of `twas-nd`, `ihs` and `twas-base` images.

## Testing

The pipelines ran successfully on feature branch (ignore failed job `summary` as it needs to run WASdev repo instead of fork):
* [twas-base CICD](https://github.com/majguo/azure.websphere-traditional.image/actions/runs/1891676423)
* [ihs CICD](https://github.com/majguo/azure.websphere-traditional.image/actions/runs/1891675825)
* [twas-nd CICD](https://github.com/majguo/azure.websphere-traditional.image/actions/runs/1891249643)

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>