### PR TITLE
Fix intermittent failure of base image building pipelines

### DIFF
--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -39,10 +39,7 @@ env:
   vhdStorageAccountName: storage${{ github.run_id }}${{ github.run_number }}
   msTeamsWebhook: ${{ secrets.MSTEAMS_WEBHOOK }}
   location: eastus
-  # Installation directory, must be updated if virtualimage.properties changed 
-  ihs_install_directory: /datadrive/IBM/WebSphere/IHS/V9/bin
-  plugin_install_directory: /datadrive/IBM/WebSphere/Plugins/V9/bin
-  wct_install_directory: /datadrive/IBM/WebSphere/Toolbox/V9/bin
+  scriptLocation: https://raw.githubusercontent.com/${{ secrets.USER_NAME }}/azure.websphere-traditional.image/$GITHUB_REF_NAME/ihs/test/
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -132,9 +129,6 @@ jobs:
           echo "Output stdout:"
           result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S cat /var/lib/waagent/custom-script/download/0/stdout')
           echo "$result"
-          echo "Output stderr:"
-          result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S cat /var/lib/waagent/custom-script/download/0/stderr')
-          echo "$result"
       - name: Install cifs-utils
         run: |
           echo "pubilc IP of VM: ${wlsPublicIP}"
@@ -176,59 +170,7 @@ jobs:
           az deployment group create --resource-group ${{ env.testResourceGroup }} \
               --name unentitled${{ github.run_id }}${{ github.run_number }} \
               --template-file ./mainTemplate.json \
-              --parameters ibmUserId=${{ env.unEntitledIbmUserId }} ibmUserPwd=${{ env.unEntitledIbmPassword }} vmName=unentitled${{ github.run_id }}${{ github.run_number }} vmAdminId=${{ env.vmAdminId }} vmAdminPwd=${{ env.vmAdminPassword }} location=${{ env.location }} imageResourceId=$imageResourceId
-      - name: Verify that the IBM installations for unentitled vm
-        run: |
-          echo "query public ip"
-          untitledVMIP=$(az vm show \
-            --resource-group ${{ env.testResourceGroup }} \
-            --name unentitled${{ github.run_id }}${{ github.run_number }} -d \
-            --query publicIps -o tsv)
-          echo "pubilc IP of VM: ${untitledVMIP}"
-          echo "Verifying WebSphere server installation"
-          echo install sshpass
-          sudo apt-get install -y sshpass
-          timeout 3m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${untitledVMIP} 22
-
-          isCloudInitReady=false
-          while [ $isCloudInitReady = false ]
-          do
-            isCloudInitReady=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${untitledVMIP} 'if [ ! -f "/var/log/cloud-init-was.log" ]; then echo false; else echo true; fi')
-            if [[ $isCloudInitReady = false ]]; then
-              echo "waiting for entitlement/evaluation check started..."
-              sleep 5
-            else
-              echo "entitlement/evaluation check started..."
-            fi
-          done
-
-          isDone=false
-          while [ $isDone = false ]
-          do
-            result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${untitledVMIP} '(tail -n1) </var/log/cloud-init-was.log')
-            # Remove special characters
-            result=$(echo $result | sed $'s/[^[:alnum:]\t]//g')
-            if [[ "$result" == "Unentitled" ]] || [[ "$result" == "Entitled" ]] || [[ "$result" == "Undefined" ]] || [[ "$result" = "Evaluation" ]]; then
-                isDone=true
-            else
-                echo "waiting for entitlement/evaluation check completed..."
-                sleep 5
-            fi
-          done
-          echo $result
-
-          if [ ${result} = Entitled ]; then
-              exit 1
-          fi
-
-          # Check the installation path is not removed
-          echo "Check the installation path is not removed"
-          pathExists=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${untitledVMIP} 'if [ -d "${{ env.ihs_install_directory }}" ] || [ -d "${{ env.plugin_install_directory }}" ] || [ -d "${{ env.wct_install_directory }}" ]; then echo true; else echo false; fi')
-          if [[ $pathExists = true ]]; then
-            echo "IBM installations still exist"
-            exit 1
-          fi
-
+              --parameters scriptLocation=${{ env.scriptLocation }} deploymentMode=Unentitled ibmUserId=${{ env.unEntitledIbmUserId }} ibmUserPwd=${{ env.unEntitledIbmPassword }} vmName=unentitled${{ github.run_id }}${{ github.run_number }} vmAdminId=${{ env.vmAdminId }} vmAdminPwd=${{ env.vmAdminPassword }} location=${{ env.location }} imageResourceId=$imageResourceId
       - name: Deploy VM using image with entitled account
         run: |
           imageResourceId=$(az image show --name ${{ env.vmName }} --resource-group ${{ env.testResourceGroup }} --query id -o tsv)
@@ -236,57 +178,7 @@ jobs:
           az deployment group create --resource-group ${{ env.testResourceGroup }} \
               --name entitled${{ github.run_id }}${{ github.run_number }} \
               --template-file ./mainTemplate.json \
-              --parameters ibmUserId=${{ env.entitledIbmUserId }} ibmUserPwd=${{ env.entitledIbmPassword }} vmName=entitled${{ github.run_id }}${{ github.run_number }} vmAdminId=${{ env.vmAdminId }} vmAdminPwd=${{ env.vmAdminPassword }} location=${{ env.location }} imageResourceId=$imageResourceId
-      - name: Verify that the IBM installations for entitled vm
-        run: |
-          echo "query public ip"
-          entitledVMIP=$(az vm show \
-            --resource-group ${{ env.testResourceGroup }} \
-            --name entitled${{ github.run_id }}${{ github.run_number }} -d \
-            --query publicIps -o tsv)
-          echo "pubilc IP of VM: ${entitledVMIP}"
-          echo "Verifying WebSphere server installation"
-          echo install sshpass
-          sudo apt-get install -y sshpass
-          timeout 1m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${entitledVMIP} 22
-          isCloudInitReady=false
-          while [ $isCloudInitReady = false ]
-          do
-            isCloudInitReady=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} 'if [ ! -f "/var/log/cloud-init-was.log" ]; then echo false; else echo true; fi')
-            if [[ $isCloudInitReady = false ]]; then
-              echo "waiting for entitlement/evaluation check started..."
-              sleep 5
-            else
-              echo "entitlement/evaluation check started..."
-            fi
-          done
-
-          isDone=false
-          while [ $isDone = false ]
-          do
-            result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} '(tail -n1) </var/log/cloud-init-was.log')
-            # Remove special characters
-            result=$(echo $result | sed $'s/[^[:alnum:]\t]//g')
-            if [[ "$result" == "Unentitled" ]] || [[ "$result" == "Entitled" ]] || [[ "$result" == "Undefined" ]] || [[ "$result" = "Evaluation" ]]; then
-                isDone=true
-            else
-                echo "waiting for entitlement/evaluation check completed..."
-                sleep 5
-            fi
-          done
-          echo $result
-
-          if [ ${result} != Entitled ]; then
-              exit 1
-          fi
-          
-          # Check the installation path is removed
-          echo "Check the installation path is removed"
-          pathExists=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} 'if [ -d "${{ env.ihs_install_directory }}" ] && [ -d "${{ env.plugin_install_directory }}" ] && [ -d "${{ env.wct_install_directory }}" ]; then echo true; else echo false; fi')
-          if [[ $pathExists = false ]]; then
-            echo "IBM installations do not exist"
-            exit 1
-          fi
+              --parameters scriptLocation=${{ env.scriptLocation }} deploymentMode=Entitled ibmUserId=${{ env.entitledIbmUserId }} ibmUserPwd=${{ env.entitledIbmPassword }} vmName=entitled${{ github.run_id }}${{ github.run_number }} vmAdminId=${{ env.vmAdminId }} vmAdminPwd=${{ env.vmAdminPassword }} location=${{ env.location }} imageResourceId=$imageResourceId
       - name: Deploy VM using image for evaluation usage
         run: |
           imageResourceId=$(az image show --name ${{ env.vmName }} --resource-group ${{ env.testResourceGroup }} --query id -o tsv)
@@ -294,57 +186,7 @@ jobs:
           az deployment group create --resource-group ${{ env.testResourceGroup }} \
               --name evaluation${{ github.run_id }}${{ github.run_number }} \
               --template-file ./mainTemplate.json \
-              --parameters ibmUserId="" ibmUserPwd="" vmName=evaluation${{ github.run_id }}${{ github.run_number }} vmAdminId=${{ env.vmAdminId }} vmAdminPwd=${{ env.vmAdminPassword }} location=${{ env.location }} imageResourceId=$imageResourceId
-      - name: Verify the IBM installations for evaluation usage
-        run: |
-          echo "query public ip"
-          evaluationVMIP=$(az vm show \
-            --resource-group ${{ env.testResourceGroup }} \
-            --name evaluation${{ github.run_id }}${{ github.run_number }} -d \
-            --query publicIps -o tsv)
-          echo "pubilc IP of VM: ${evaluationVMIP}"
-          echo "Verifying WebSphere server installation"
-          echo install sshpass
-          sudo apt-get install -y sshpass
-          timeout 1m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${evaluationVMIP} 22
-          isCloudInitReady=false
-          while [ $isCloudInitReady = false ]
-          do
-            isCloudInitReady=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${evaluationVMIP} 'if [ ! -f "/var/log/cloud-init-was.log" ]; then echo false; else echo true; fi')
-            if [[ $isCloudInitReady = false ]]; then
-              echo "waiting for entitlement/evaluation check started..."
-              sleep 5
-            else
-              echo "entitlement/evaluation check started..."
-            fi
-          done
-
-          isDone=false
-          while [ $isDone = false ]
-          do
-            result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${evaluationVMIP} '(tail -n1) </var/log/cloud-init-was.log')
-            # Remove special characters
-            result=$(echo $result | sed $'s/[^[:alnum:]\t]//g')
-            if [[ "$result" == "Unentitled" ]] || [[ "$result" == "Entitled" ]] || [[ "$result" == "Undefined" ]] || [[ "$result" = "Evaluation" ]]; then
-                isDone=true
-            else
-                echo "waiting for entitlement/evaluation check completed..."
-                sleep 5
-            fi
-          done
-          echo $result
-
-          if [ ${result} != Evaluation ]; then
-              exit 1
-          fi
-          
-          # Check the installation path exists
-          echo "Check the installation path exists"
-          pathExists=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${evaluationVMIP} 'if [ -d "${{ env.ihs_install_directory }}" ] && [ -d "${{ env.plugin_install_directory }}" ] && [ -d "${{ env.wct_install_directory }}" ]; then echo true; else echo false; fi')
-          if [[ $pathExists = false ]]; then
-            echo "IBM installations do not exist"
-            exit 1
-          fi
+              --parameters scriptLocation=${{ env.scriptLocation }} deploymentMode=Evaluation ibmUserId="" ibmUserPwd="" vmName=evaluation${{ github.run_id }}${{ github.run_number }} vmAdminId=${{ env.vmAdminId }} vmAdminPwd=${{ env.vmAdminPassword }} location=${{ env.location }} imageResourceId=$imageResourceId
       - name: Generate SAS url
         id: generate-sas-blob-url
         run: |

--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -130,10 +130,10 @@ jobs:
           sudo apt-get install -y sshpass
           timeout 1m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${wlsPublicIP} 22
           echo "Output stdout:"
-          result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S cat /var/lib/waagent/custom-script/download/0/stdout')
+          result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S cat /var/lib/waagent/custom-script/download/0/stdout')
           echo "$result"
           echo "Output stderr:"
-          result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S cat /var/lib/waagent/custom-script/download/0/stderr')
+          result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S cat /var/lib/waagent/custom-script/download/0/stderr')
           echo "$result"
       - name: Install cifs-utils
         run: |
@@ -142,7 +142,7 @@ jobs:
           echo install sshpass
           sudo apt-get install -y sshpass
           timeout 1m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${wlsPublicIP} 22
-          sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S yum install cifs-utils -y'
+          sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S yum install cifs-utils -y'
       - name: Update applications
         run: |
           echo "pubilc IP of VM: ${wlsPublicIP}"
@@ -150,7 +150,7 @@ jobs:
           echo install sshpass
           sudo apt-get install -y sshpass
           timeout 1m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${wlsPublicIP} 22
-          sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S yum update -y'
+          sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S yum update -y'
       - name: Deprovision
         run: |
           echo "pubilc IP of VM: ${wlsPublicIP}"
@@ -158,7 +158,7 @@ jobs:
           echo install sshpass
           sudo apt-get install -y sshpass
           timeout 1m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${wlsPublicIP} 22
-          sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S waagent -deprovision+user -force'
+          sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S waagent -deprovision+user -force'
       - name: Generate VM Image
         run: |
           # Update the access level of vhd container
@@ -193,7 +193,7 @@ jobs:
           isCloudInitReady=false
           while [ $isCloudInitReady = false ]
           do
-            isCloudInitReady=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${untitledVMIP} 'if [ ! -f "/var/log/cloud-init-was.log" ]; then echo false; else echo true; fi')
+            isCloudInitReady=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${untitledVMIP} 'if [ ! -f "/var/log/cloud-init-was.log" ]; then echo false; else echo true; fi')
             if [[ $isCloudInitReady = false ]]; then
               echo "waiting for entitlement/evaluation check started..."
               sleep 5
@@ -205,7 +205,7 @@ jobs:
           isDone=false
           while [ $isDone = false ]
           do
-            result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${untitledVMIP} '(tail -n1) </var/log/cloud-init-was.log')
+            result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${untitledVMIP} '(tail -n1) </var/log/cloud-init-was.log')
             # Remove special characters
             result=$(echo $result | sed $'s/[^[:alnum:]\t]//g')
             if [[ "$result" == "Unentitled" ]] || [[ "$result" == "Entitled" ]] || [[ "$result" == "Undefined" ]] || [[ "$result" = "Evaluation" ]]; then
@@ -223,7 +223,7 @@ jobs:
 
           # Check the installation path is not removed
           echo "Check the installation path is not removed"
-          pathExists=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${untitledVMIP} 'if [ -d "${{ env.ihs_install_directory }}" ] || [ -d "${{ env.plugin_install_directory }}" ] || [ -d "${{ env.wct_install_directory }}" ]; then echo true; else echo false; fi')
+          pathExists=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${untitledVMIP} 'if [ -d "${{ env.ihs_install_directory }}" ] || [ -d "${{ env.plugin_install_directory }}" ] || [ -d "${{ env.wct_install_directory }}" ]; then echo true; else echo false; fi')
           if [[ $pathExists = true ]]; then
             echo "IBM installations still exist"
             exit 1
@@ -252,7 +252,7 @@ jobs:
           isCloudInitReady=false
           while [ $isCloudInitReady = false ]
           do
-            isCloudInitReady=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} 'if [ ! -f "/var/log/cloud-init-was.log" ]; then echo false; else echo true; fi')
+            isCloudInitReady=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} 'if [ ! -f "/var/log/cloud-init-was.log" ]; then echo false; else echo true; fi')
             if [[ $isCloudInitReady = false ]]; then
               echo "waiting for entitlement/evaluation check started..."
               sleep 5
@@ -264,7 +264,7 @@ jobs:
           isDone=false
           while [ $isDone = false ]
           do
-            result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} '(tail -n1) </var/log/cloud-init-was.log')
+            result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} '(tail -n1) </var/log/cloud-init-was.log')
             # Remove special characters
             result=$(echo $result | sed $'s/[^[:alnum:]\t]//g')
             if [[ "$result" == "Unentitled" ]] || [[ "$result" == "Entitled" ]] || [[ "$result" == "Undefined" ]] || [[ "$result" = "Evaluation" ]]; then
@@ -282,7 +282,7 @@ jobs:
           
           # Check the installation path is removed
           echo "Check the installation path is removed"
-          pathExists=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} 'if [ -d "${{ env.ihs_install_directory }}" ] && [ -d "${{ env.plugin_install_directory }}" ] && [ -d "${{ env.wct_install_directory }}" ]; then echo true; else echo false; fi')
+          pathExists=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} 'if [ -d "${{ env.ihs_install_directory }}" ] && [ -d "${{ env.plugin_install_directory }}" ] && [ -d "${{ env.wct_install_directory }}" ]; then echo true; else echo false; fi')
           if [[ $pathExists = false ]]; then
             echo "IBM installations do not exist"
             exit 1
@@ -310,7 +310,7 @@ jobs:
           isCloudInitReady=false
           while [ $isCloudInitReady = false ]
           do
-            isCloudInitReady=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${evaluationVMIP} 'if [ ! -f "/var/log/cloud-init-was.log" ]; then echo false; else echo true; fi')
+            isCloudInitReady=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${evaluationVMIP} 'if [ ! -f "/var/log/cloud-init-was.log" ]; then echo false; else echo true; fi')
             if [[ $isCloudInitReady = false ]]; then
               echo "waiting for entitlement/evaluation check started..."
               sleep 5
@@ -322,7 +322,7 @@ jobs:
           isDone=false
           while [ $isDone = false ]
           do
-            result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${evaluationVMIP} '(tail -n1) </var/log/cloud-init-was.log')
+            result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${evaluationVMIP} '(tail -n1) </var/log/cloud-init-was.log')
             # Remove special characters
             result=$(echo $result | sed $'s/[^[:alnum:]\t]//g')
             if [[ "$result" == "Unentitled" ]] || [[ "$result" == "Entitled" ]] || [[ "$result" == "Undefined" ]] || [[ "$result" = "Evaluation" ]]; then
@@ -340,7 +340,7 @@ jobs:
           
           # Check the installation path exists
           echo "Check the installation path exists"
-          pathExists=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${evaluationVMIP} 'if [ -d "${{ env.ihs_install_directory }}" ] && [ -d "${{ env.plugin_install_directory }}" ] && [ -d "${{ env.wct_install_directory }}" ]; then echo true; else echo false; fi')
+          pathExists=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${evaluationVMIP} 'if [ -d "${{ env.ihs_install_directory }}" ] && [ -d "${{ env.plugin_install_directory }}" ] && [ -d "${{ env.wct_install_directory }}" ]; then echo true; else echo false; fi')
           if [[ $pathExists = false ]]; then
             echo "IBM installations do not exist"
             exit 1

--- a/.github/workflows/twas-baseBuild.yml
+++ b/.github/workflows/twas-baseBuild.yml
@@ -39,8 +39,7 @@ env:
   vhdStorageAccountName: storage${{ github.run_id }}${{ github.run_number }}
   msTeamsWebhook: ${{ secrets.MSTEAMS_WEBHOOK }}
   location: eastus
-  # Installation directory, must be updated if virtualimage.properties/WAS_BASE_INSTALL_DIRECTORY changed 
-  was_base_install_directory: /datadrive/IBM/WebSphere/Base/V9/bin
+  scriptLocation: https://raw.githubusercontent.com/${{ secrets.USER_NAME }}/azure.websphere-traditional.image/$GITHUB_REF_NAME/twas-base/test/
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -128,9 +127,6 @@ jobs:
           echo "Output stdout:"
           result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S cat /var/lib/waagent/custom-script/download/0/stdout')
           echo "$result"
-          echo "Output stderr:"
-          result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S cat /var/lib/waagent/custom-script/download/0/stderr')
-          echo "$result"
       - name: Install cifs-utils
         run: |
           echo "pubilc IP of VM: ${wlsPublicIP}"
@@ -172,59 +168,7 @@ jobs:
           az deployment group create --resource-group ${{ env.testResourceGroup }} \
               --name unentitled${{ github.run_id }}${{ github.run_number }} \
               --template-file ./mainTemplate.json \
-              --parameters ibmUserId=${{ env.unEntitledIbmUserId }} ibmUserPwd=${{ env.unEntitledIbmPassword }} vmName=unentitled${{ github.run_id }}${{ github.run_number }} vmAdminId=${{ env.vmAdminId }} vmAdminPwd=${{ env.vmAdminPassword }} location=${{ env.location }} imageResourceId=$imageResourceId
-      - name: Verify that the IBM installations for unentitled vm
-        run: |
-          echo "query public ip"
-          untitledVMIP=$(az vm show \
-            --resource-group ${{ env.testResourceGroup }} \
-            --name unentitled${{ github.run_id }}${{ github.run_number }} -d \
-            --query publicIps -o tsv)
-          echo "pubilc IP of VM: ${untitledVMIP}"
-          echo "Verifying WebSphere server installation"
-          echo install sshpass
-          sudo apt-get install -y sshpass
-          timeout 3m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${untitledVMIP} 22
-
-          isCloudInitReady=false
-          while [ $isCloudInitReady = false ]
-          do
-            isCloudInitReady=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${untitledVMIP} 'if [ ! -f "/var/log/cloud-init-was.log" ]; then echo false; else echo true; fi')
-            if [[ $isCloudInitReady = false ]]; then
-              echo "waiting for was entitlement/evaluation check started..."
-              sleep 5
-            else
-              echo "was entitlement/evaluation check started..."
-            fi
-          done
-
-          isDone=false
-          while [ $isDone = false ]
-          do
-            result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${untitledVMIP} '(tail -n1) </var/log/cloud-init-was.log')
-            # Remove special characters
-            result=$(echo $result | sed $'s/[^[:alnum:]\t]//g')
-            if [[ "$result" == "Unentitled" ]] || [[ "$result" == "Entitled" ]] || [[ "$result" == "Undefined" ]] || [[ "$result" = "Evaluation" ]]; then
-                isDone=true
-            else
-                echo "waiting for was entitlement/evaluation check completed..."
-                sleep 5
-            fi
-          done
-          echo $result
-
-          if [ ${result} = Entitled ]; then
-              exit 1
-          fi
-
-          # Check the installation path is not removed
-          echo "Check the installation path is not removed"
-          pathExists=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${untitledVMIP} 'if [ -d "${{ env.was_base_install_directory }}" ]; then echo true; else echo false; fi')
-          if [[ $pathExists = true ]]; then
-            echo "IBM installations still exist"
-            exit 1
-          fi
-
+              --parameters scriptLocation=${{ env.scriptLocation }} deploymentMode=Unentitled ibmUserId=${{ env.unEntitledIbmUserId }} ibmUserPwd=${{ env.unEntitledIbmPassword }} vmName=unentitled${{ github.run_id }}${{ github.run_number }} vmAdminId=${{ env.vmAdminId }} vmAdminPwd=${{ env.vmAdminPassword }} location=${{ env.location }} imageResourceId=$imageResourceId
       - name: Deploy VM using image with entitled account
         run: |
           imageResourceId=$(az image show --name ${{ env.vmName }} --resource-group ${{ env.testResourceGroup }} --query id -o tsv)
@@ -232,57 +176,7 @@ jobs:
           az deployment group create --resource-group ${{ env.testResourceGroup }} \
               --name entitled${{ github.run_id }}${{ github.run_number }} \
               --template-file ./mainTemplate.json \
-              --parameters ibmUserId=${{ env.entitledIbmUserId }} ibmUserPwd=${{ env.entitledIbmPassword }} vmName=entitled${{ github.run_id }}${{ github.run_number }} vmAdminId=${{ env.vmAdminId }} vmAdminPwd=${{ env.vmAdminPassword }} location=${{ env.location }} imageResourceId=$imageResourceId
-      - name: Verify that the IBM installations for entitled vm
-        run: |
-          echo "query public ip"
-          entitledVMIP=$(az vm show \
-            --resource-group ${{ env.testResourceGroup }} \
-            --name entitled${{ github.run_id }}${{ github.run_number }} -d \
-            --query publicIps -o tsv)
-          echo "pubilc IP of VM: ${entitledVMIP}"
-          echo "Verifying WebSphere server installation"
-          echo install sshpass
-          sudo apt-get install -y sshpass
-          timeout 1m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${entitledVMIP} 22
-          isCloudInitReady=false
-          while [ $isCloudInitReady = false ]
-          do
-            isCloudInitReady=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} 'if [ ! -f "/var/log/cloud-init-was.log" ]; then echo false; else echo true; fi')
-            if [[ $isCloudInitReady = false ]]; then
-              echo "waiting for was entitlement/evaluation check started..."
-              sleep 5
-            else
-              echo "was entitlement/evaluation check started..."
-            fi
-          done
-
-          isDone=false
-          while [ $isDone = false ]
-          do
-            result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} '(tail -n1) </var/log/cloud-init-was.log')
-            # Remove special characters
-            result=$(echo $result | sed $'s/[^[:alnum:]\t]//g')
-            if [[ "$result" == "Unentitled" ]] || [[ "$result" == "Entitled" ]] || [[ "$result" == "Undefined" ]] || [[ "$result" = "Evaluation" ]]; then
-                isDone=true
-            else
-                echo "waiting for was entitlement/evaluation check completed..."
-                sleep 5
-            fi
-          done
-          echo $result
-
-          if [ ${result} != Entitled ]; then
-              exit 1
-          fi
-          
-          # Check the installation path is removed
-          echo "Check the installation path is removed"
-          pathExists=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} 'if [ -d "${{ env.was_base_install_directory }}" ]; then echo true; else echo false; fi')
-          if [[ $pathExists = false ]]; then
-            echo "IBM installations do not exist"
-            exit 1
-          fi
+              --parameters scriptLocation=${{ env.scriptLocation }} deploymentMode=Entitled ibmUserId=${{ env.entitledIbmUserId }} ibmUserPwd=${{ env.entitledIbmPassword }} vmName=entitled${{ github.run_id }}${{ github.run_number }} vmAdminId=${{ env.vmAdminId }} vmAdminPwd=${{ env.vmAdminPassword }} location=${{ env.location }} imageResourceId=$imageResourceId
       - name: Deploy VM using image for evaluation usage
         run: |
           imageResourceId=$(az image show --name ${{ env.vmName }} --resource-group ${{ env.testResourceGroup }} --query id -o tsv)
@@ -290,57 +184,7 @@ jobs:
           az deployment group create --resource-group ${{ env.testResourceGroup }} \
               --name evaluation${{ github.run_id }}${{ github.run_number }} \
               --template-file ./mainTemplate.json \
-              --parameters ibmUserId="" ibmUserPwd="" vmName=evaluation${{ github.run_id }}${{ github.run_number }} vmAdminId=${{ env.vmAdminId }} vmAdminPwd=${{ env.vmAdminPassword }} location=${{ env.location }} imageResourceId=$imageResourceId
-      - name: Verify the IBM installations for evaluation usage
-        run: |
-          echo "query public ip"
-          evaluationVMIP=$(az vm show \
-            --resource-group ${{ env.testResourceGroup }} \
-            --name evaluation${{ github.run_id }}${{ github.run_number }} -d \
-            --query publicIps -o tsv)
-          echo "pubilc IP of VM: ${evaluationVMIP}"
-          echo "Verifying WebSphere server installation"
-          echo install sshpass
-          sudo apt-get install -y sshpass
-          timeout 1m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${evaluationVMIP} 22
-          isCloudInitReady=false
-          while [ $isCloudInitReady = false ]
-          do
-            isCloudInitReady=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${evaluationVMIP} 'if [ ! -f "/var/log/cloud-init-was.log" ]; then echo false; else echo true; fi')
-            if [[ $isCloudInitReady = false ]]; then
-              echo "waiting for entitlement/evaluation check started..."
-              sleep 5
-            else
-              echo "entitlement/evaluation check started..."
-            fi
-          done
-
-          isDone=false
-          while [ $isDone = false ]
-          do
-            result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${evaluationVMIP} '(tail -n1) </var/log/cloud-init-was.log')
-            # Remove special characters
-            result=$(echo $result | sed $'s/[^[:alnum:]\t]//g')
-            if [[ "$result" == "Unentitled" ]] || [[ "$result" == "Entitled" ]] || [[ "$result" == "Undefined" ]] || [[ "$result" = "Evaluation" ]]; then
-                isDone=true
-            else
-                echo "waiting for entitlement/evaluation check completed..."
-                sleep 5
-            fi
-          done
-          echo $result
-
-          if [ ${result} != Evaluation ]; then
-              exit 1
-          fi
-          
-          # Check the installation path exists
-          echo "Check the installation path exists"
-          pathExists=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${evaluationVMIP} 'if [ -d "${{ env.was_base_install_directory }}" ]; then echo true; else echo false; fi')
-          if [[ $pathExists = false ]]; then
-            echo "IBM installations do not exist"
-            exit 1
-          fi
+              --parameters scriptLocation=${{ env.scriptLocation }} deploymentMode=Evaluation ibmUserId="" ibmUserPwd="" vmName=evaluation${{ github.run_id }}${{ github.run_number }} vmAdminId=${{ env.vmAdminId }} vmAdminPwd=${{ env.vmAdminPassword }} location=${{ env.location }} imageResourceId=$imageResourceId
       - name: Generate SAS url
         id: generate-sas-blob-url
         run: |

--- a/.github/workflows/twas-baseBuild.yml
+++ b/.github/workflows/twas-baseBuild.yml
@@ -126,10 +126,10 @@ jobs:
           sudo apt-get install -y sshpass
           timeout 1m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${wlsPublicIP} 22
           echo "Output stdout:"
-          result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S cat /var/lib/waagent/custom-script/download/0/stdout')
+          result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S cat /var/lib/waagent/custom-script/download/0/stdout')
           echo "$result"
           echo "Output stderr:"
-          result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S cat /var/lib/waagent/custom-script/download/0/stderr')
+          result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S cat /var/lib/waagent/custom-script/download/0/stderr')
           echo "$result"
       - name: Install cifs-utils
         run: |
@@ -138,7 +138,7 @@ jobs:
           echo install sshpass
           sudo apt-get install -y sshpass
           timeout 1m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${wlsPublicIP} 22
-          sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo  -S yum install cifs-utils -y'
+          sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo  -S yum install cifs-utils -y'
       - name: Update applications
         run: |
           echo "pubilc IP of VM: ${wlsPublicIP}"
@@ -146,7 +146,7 @@ jobs:
           echo install sshpass
           sudo apt-get install -y sshpass
           timeout 1m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${wlsPublicIP} 22
-          sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S yum update -y'
+          sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S yum update -y'
       - name: Deprovision
         run: |
           echo "pubilc IP of VM: ${wlsPublicIP}"
@@ -154,7 +154,7 @@ jobs:
           echo install sshpass
           sudo apt-get install -y sshpass
           timeout 1m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${wlsPublicIP} 22
-          sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S waagent -deprovision+user -force'
+          sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S waagent -deprovision+user -force'
       - name: Generate VM Image
         run: |
           # Update the access level of vhd container
@@ -189,7 +189,7 @@ jobs:
           isCloudInitReady=false
           while [ $isCloudInitReady = false ]
           do
-            isCloudInitReady=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${untitledVMIP} 'if [ ! -f "/var/log/cloud-init-was.log" ]; then echo false; else echo true; fi')
+            isCloudInitReady=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${untitledVMIP} 'if [ ! -f "/var/log/cloud-init-was.log" ]; then echo false; else echo true; fi')
             if [[ $isCloudInitReady = false ]]; then
               echo "waiting for was entitlement/evaluation check started..."
               sleep 5
@@ -201,7 +201,7 @@ jobs:
           isDone=false
           while [ $isDone = false ]
           do
-            result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${untitledVMIP} '(tail -n1) </var/log/cloud-init-was.log')
+            result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${untitledVMIP} '(tail -n1) </var/log/cloud-init-was.log')
             # Remove special characters
             result=$(echo $result | sed $'s/[^[:alnum:]\t]//g')
             if [[ "$result" == "Unentitled" ]] || [[ "$result" == "Entitled" ]] || [[ "$result" == "Undefined" ]] || [[ "$result" = "Evaluation" ]]; then
@@ -219,7 +219,7 @@ jobs:
 
           # Check the installation path is not removed
           echo "Check the installation path is not removed"
-          pathExists=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${untitledVMIP} 'if [ -d "${{ env.was_base_install_directory }}" ]; then echo true; else echo false; fi')
+          pathExists=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${untitledVMIP} 'if [ -d "${{ env.was_base_install_directory }}" ]; then echo true; else echo false; fi')
           if [[ $pathExists = true ]]; then
             echo "IBM installations still exist"
             exit 1
@@ -248,7 +248,7 @@ jobs:
           isCloudInitReady=false
           while [ $isCloudInitReady = false ]
           do
-            isCloudInitReady=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} 'if [ ! -f "/var/log/cloud-init-was.log" ]; then echo false; else echo true; fi')
+            isCloudInitReady=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} 'if [ ! -f "/var/log/cloud-init-was.log" ]; then echo false; else echo true; fi')
             if [[ $isCloudInitReady = false ]]; then
               echo "waiting for was entitlement/evaluation check started..."
               sleep 5
@@ -260,7 +260,7 @@ jobs:
           isDone=false
           while [ $isDone = false ]
           do
-            result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} '(tail -n1) </var/log/cloud-init-was.log')
+            result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} '(tail -n1) </var/log/cloud-init-was.log')
             # Remove special characters
             result=$(echo $result | sed $'s/[^[:alnum:]\t]//g')
             if [[ "$result" == "Unentitled" ]] || [[ "$result" == "Entitled" ]] || [[ "$result" == "Undefined" ]] || [[ "$result" = "Evaluation" ]]; then
@@ -278,7 +278,7 @@ jobs:
           
           # Check the installation path is removed
           echo "Check the installation path is removed"
-          pathExists=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} 'if [ -d "${{ env.was_base_install_directory }}" ]; then echo true; else echo false; fi')
+          pathExists=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} 'if [ -d "${{ env.was_base_install_directory }}" ]; then echo true; else echo false; fi')
           if [[ $pathExists = false ]]; then
             echo "IBM installations do not exist"
             exit 1
@@ -306,7 +306,7 @@ jobs:
           isCloudInitReady=false
           while [ $isCloudInitReady = false ]
           do
-            isCloudInitReady=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${evaluationVMIP} 'if [ ! -f "/var/log/cloud-init-was.log" ]; then echo false; else echo true; fi')
+            isCloudInitReady=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${evaluationVMIP} 'if [ ! -f "/var/log/cloud-init-was.log" ]; then echo false; else echo true; fi')
             if [[ $isCloudInitReady = false ]]; then
               echo "waiting for entitlement/evaluation check started..."
               sleep 5
@@ -318,7 +318,7 @@ jobs:
           isDone=false
           while [ $isDone = false ]
           do
-            result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${evaluationVMIP} '(tail -n1) </var/log/cloud-init-was.log')
+            result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${evaluationVMIP} '(tail -n1) </var/log/cloud-init-was.log')
             # Remove special characters
             result=$(echo $result | sed $'s/[^[:alnum:]\t]//g')
             if [[ "$result" == "Unentitled" ]] || [[ "$result" == "Entitled" ]] || [[ "$result" == "Undefined" ]] || [[ "$result" = "Evaluation" ]]; then
@@ -336,7 +336,7 @@ jobs:
           
           # Check the installation path exists
           echo "Check the installation path exists"
-          pathExists=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${evaluationVMIP} 'if [ -d "${{ env.was_base_install_directory }}" ]; then echo true; else echo false; fi')
+          pathExists=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${evaluationVMIP} 'if [ -d "${{ env.was_base_install_directory }}" ]; then echo true; else echo false; fi')
           if [[ $pathExists = false ]]; then
             echo "IBM installations do not exist"
             exit 1

--- a/.github/workflows/twas-ndBuild.yml
+++ b/.github/workflows/twas-ndBuild.yml
@@ -128,10 +128,10 @@ jobs:
           sudo apt-get install -y sshpass
           timeout 1m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${wlsPublicIP} 22
           echo "Output stdout:"
-          result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S cat /var/lib/waagent/custom-script/download/0/stdout')
+          result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S cat /var/lib/waagent/custom-script/download/0/stdout')
           echo "$result"
           echo "Output stderr:"
-          result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S cat /var/lib/waagent/custom-script/download/0/stderr')
+          result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S cat /var/lib/waagent/custom-script/download/0/stderr')
           echo "$result"
       - name: Install cifs-utils
         run: |
@@ -140,7 +140,7 @@ jobs:
           echo install sshpass
           sudo apt-get install -y sshpass
           timeout 1m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${wlsPublicIP} 22
-          sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo  -S yum install cifs-utils -y'
+          sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo  -S yum install cifs-utils -y'
       - name: Update applications
         run: |
           echo "pubilc IP of VM: ${wlsPublicIP}"
@@ -148,7 +148,7 @@ jobs:
           echo install sshpass
           sudo apt-get install -y sshpass
           timeout 1m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${wlsPublicIP} 22
-          sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S yum update -y'
+          sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S yum update -y'
       - name: Deprovision
         run: |
           echo "pubilc IP of VM: ${wlsPublicIP}"
@@ -156,7 +156,7 @@ jobs:
           echo install sshpass
           sudo apt-get install -y sshpass
           timeout 1m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${wlsPublicIP} 22
-          sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S waagent -deprovision+user -force'
+          sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S waagent -deprovision+user -force'
       - name: Generate VM Image
         run: |
           # Update the access level of vhd container
@@ -191,7 +191,7 @@ jobs:
           isCloudInitReady=false
           while [ $isCloudInitReady = false ]
           do
-            isCloudInitReady=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${untitledVMIP} 'if [ ! -f "/var/log/cloud-init-was.log" ]; then echo false; else echo true; fi')
+            isCloudInitReady=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${untitledVMIP} 'if [ ! -f "/var/log/cloud-init-was.log" ]; then echo false; else echo true; fi')
             if [[ $isCloudInitReady = false ]]; then
               echo "waiting for was entitlement/evaluation check started..."
               sleep 5
@@ -203,7 +203,7 @@ jobs:
           isDone=false
           while [ $isDone = false ]
           do
-            result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${untitledVMIP} '(tail -n1) </var/log/cloud-init-was.log')
+            result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${untitledVMIP} '(tail -n1) </var/log/cloud-init-was.log')
             # Remove special characters
             result=$(echo $result | sed $'s/[^[:alnum:]\t]//g')
             if [[ "$result" == "Unentitled" ]] || [[ "$result" == "Entitled" ]] || [[ "$result" == "Undefined" ]] || [[ "$result" = "Evaluation" ]]; then
@@ -221,7 +221,7 @@ jobs:
 
           # Check the installation path is not removed
           echo "Check the installation path is not removed"
-          pathExists=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${untitledVMIP} 'if [ -d "${{ env.was_nd_install_directory }}" ]; then echo true; else echo false; fi')
+          pathExists=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${untitledVMIP} 'if [ -d "${{ env.was_nd_install_directory }}" ]; then echo true; else echo false; fi')
           if [[ $pathExists = true ]]; then
             echo "IBM installations still exist"
             exit 1
@@ -250,7 +250,7 @@ jobs:
           isCloudInitReady=false
           while [ $isCloudInitReady = false ]
           do
-            isCloudInitReady=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} 'if [ ! -f "/var/log/cloud-init-was.log" ]; then echo false; else echo true; fi')
+            isCloudInitReady=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} 'if [ ! -f "/var/log/cloud-init-was.log" ]; then echo false; else echo true; fi')
             if [[ $isCloudInitReady = false ]]; then
               echo "waiting for was entitlement/evaluation check started..."
               sleep 5
@@ -262,7 +262,7 @@ jobs:
           isDone=false
           while [ $isDone = false ]
           do
-            result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} '(tail -n1) </var/log/cloud-init-was.log')
+            result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} '(tail -n1) </var/log/cloud-init-was.log')
             # Remove special characters
             result=$(echo $result | sed $'s/[^[:alnum:]\t]//g')
             if [[ "$result" == "Unentitled" ]] || [[ "$result" == "Entitled" ]] || [[ "$result" == "Undefined" ]] || [[ "$result" = "Evaluation" ]]; then
@@ -280,7 +280,7 @@ jobs:
           
           # Check the installation path is removed
           echo "Check the installation path is removed"
-          pathExists=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} 'if [ -d "${{ env.was_nd_install_directory }}" ]; then echo true; else echo false; fi')
+          pathExists=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} 'if [ -d "${{ env.was_nd_install_directory }}" ]; then echo true; else echo false; fi')
           if [[ $pathExists = false ]]; then
             echo "IBM installations do not exist"
             exit 1
@@ -308,7 +308,7 @@ jobs:
           isCloudInitReady=false
           while [ $isCloudInitReady = false ]
           do
-            isCloudInitReady=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${evaluationVMIP} 'if [ ! -f "/var/log/cloud-init-was.log" ]; then echo false; else echo true; fi')
+            isCloudInitReady=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${evaluationVMIP} 'if [ ! -f "/var/log/cloud-init-was.log" ]; then echo false; else echo true; fi')
             if [[ $isCloudInitReady = false ]]; then
               echo "waiting for entitlement/evaluation check started..."
               sleep 5
@@ -320,7 +320,7 @@ jobs:
           isDone=false
           while [ $isDone = false ]
           do
-            result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${evaluationVMIP} '(tail -n1) </var/log/cloud-init-was.log')
+            result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${evaluationVMIP} '(tail -n1) </var/log/cloud-init-was.log')
             # Remove special characters
             result=$(echo $result | sed $'s/[^[:alnum:]\t]//g')
             if [[ "$result" == "Unentitled" ]] || [[ "$result" == "Entitled" ]] || [[ "$result" == "Undefined" ]] || [[ "$result" = "Evaluation" ]]; then
@@ -338,7 +338,7 @@ jobs:
           
           # Check the installation path exists
           echo "Check the installation path exists"
-          pathExists=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${evaluationVMIP} 'if [ -d "${{ env.was_nd_install_directory }}" ]; then echo true; else echo false; fi')
+          pathExists=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${evaluationVMIP} 'if [ -d "${{ env.was_nd_install_directory }}" ]; then echo true; else echo false; fi')
           if [[ $pathExists = false ]]; then
             echo "IBM installations do not exist"
             exit 1

--- a/.github/workflows/twas-ndBuild.yml
+++ b/.github/workflows/twas-ndBuild.yml
@@ -39,8 +39,7 @@ env:
   vhdStorageAccountName: storage${{ github.run_id }}${{ github.run_number }}
   msTeamsWebhook: ${{ secrets.MSTEAMS_WEBHOOK }}
   location: eastus
-  # Installation directory, must be updated if virtualimage.properties/WAS_ND_INSTALL_DIRECTORY changed 
-  was_nd_install_directory: /datadrive/IBM/WebSphere/ND/V9/bin
+  scriptLocation: https://raw.githubusercontent.com/${{ secrets.USER_NAME }}/azure.websphere-traditional.image/$GITHUB_REF_NAME/twas-nd/test/
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -130,9 +129,6 @@ jobs:
           echo "Output stdout:"
           result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S cat /var/lib/waagent/custom-script/download/0/stdout')
           echo "$result"
-          echo "Output stderr:"
-          result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${wlsPublicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S cat /var/lib/waagent/custom-script/download/0/stderr')
-          echo "$result"
       - name: Install cifs-utils
         run: |
           echo "pubilc IP of VM: ${wlsPublicIP}"
@@ -174,59 +170,7 @@ jobs:
           az deployment group create --resource-group ${{ env.testResourceGroup }} \
               --name unentitled${{ github.run_id }}${{ github.run_number }} \
               --template-file ./mainTemplate.json \
-              --parameters ibmUserId=${{ env.unEntitledIbmUserId }} ibmUserPwd=${{ env.unEntitledIbmPassword }} vmName=unentitled${{ github.run_id }}${{ github.run_number }} vmAdminId=${{ env.vmAdminId }} vmAdminPwd=${{ env.vmAdminPassword }} location=${{ env.location }} imageResourceId=$imageResourceId
-      - name: Verify that the IBM installations for unentitled vm
-        run: |
-          echo "query public ip"
-          untitledVMIP=$(az vm show \
-            --resource-group ${{ env.testResourceGroup }} \
-            --name unentitled${{ github.run_id }}${{ github.run_number }} -d \
-            --query publicIps -o tsv)
-          echo "pubilc IP of VM: ${untitledVMIP}"
-          echo "Verifying WebSphere server installation"
-          echo install sshpass
-          sudo apt-get install -y sshpass
-          timeout 3m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${untitledVMIP} 22
-
-          isCloudInitReady=false
-          while [ $isCloudInitReady = false ]
-          do
-            isCloudInitReady=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${untitledVMIP} 'if [ ! -f "/var/log/cloud-init-was.log" ]; then echo false; else echo true; fi')
-            if [[ $isCloudInitReady = false ]]; then
-              echo "waiting for was entitlement/evaluation check started..."
-              sleep 5
-            else
-              echo "was entitlement/evaluation check started..."
-            fi
-          done
-
-          isDone=false
-          while [ $isDone = false ]
-          do
-            result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${untitledVMIP} '(tail -n1) </var/log/cloud-init-was.log')
-            # Remove special characters
-            result=$(echo $result | sed $'s/[^[:alnum:]\t]//g')
-            if [[ "$result" == "Unentitled" ]] || [[ "$result" == "Entitled" ]] || [[ "$result" == "Undefined" ]] || [[ "$result" = "Evaluation" ]]; then
-                isDone=true
-            else
-                echo "waiting for was entitlement/evaluation check completed..."
-                sleep 5
-            fi
-          done
-          echo $result
-
-          if [ ${result} = Entitled ]; then
-              exit 1
-          fi
-
-          # Check the installation path is not removed
-          echo "Check the installation path is not removed"
-          pathExists=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${untitledVMIP} 'if [ -d "${{ env.was_nd_install_directory }}" ]; then echo true; else echo false; fi')
-          if [[ $pathExists = true ]]; then
-            echo "IBM installations still exist"
-            exit 1
-          fi
-
+              --parameters scriptLocation=${{ env.scriptLocation }} deploymentMode=Unentitled ibmUserId=${{ env.unEntitledIbmUserId }} ibmUserPwd=${{ env.unEntitledIbmPassword }} vmName=unentitled${{ github.run_id }}${{ github.run_number }} vmAdminId=${{ env.vmAdminId }} vmAdminPwd=${{ env.vmAdminPassword }} location=${{ env.location }} imageResourceId=$imageResourceId
       - name: Deploy VM using image with entitled account
         run: |
           imageResourceId=$(az image show --name ${{ env.vmName }} --resource-group ${{ env.testResourceGroup }} --query id -o tsv)
@@ -234,57 +178,7 @@ jobs:
           az deployment group create --resource-group ${{ env.testResourceGroup }} \
               --name entitled${{ github.run_id }}${{ github.run_number }} \
               --template-file ./mainTemplate.json \
-              --parameters ibmUserId=${{ env.entitledIbmUserId }} ibmUserPwd=${{ env.entitledIbmPassword }} vmName=entitled${{ github.run_id }}${{ github.run_number }} vmAdminId=${{ env.vmAdminId }} vmAdminPwd=${{ env.vmAdminPassword }} location=${{ env.location }} imageResourceId=$imageResourceId
-      - name: Verify that the IBM installations for entitled vm
-        run: |
-          echo "query public ip"
-          entitledVMIP=$(az vm show \
-            --resource-group ${{ env.testResourceGroup }} \
-            --name entitled${{ github.run_id }}${{ github.run_number }} -d \
-            --query publicIps -o tsv)
-          echo "pubilc IP of VM: ${entitledVMIP}"
-          echo "Verifying WebSphere server installation"
-          echo install sshpass
-          sudo apt-get install -y sshpass
-          timeout 1m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${entitledVMIP} 22
-          isCloudInitReady=false
-          while [ $isCloudInitReady = false ]
-          do
-            isCloudInitReady=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} 'if [ ! -f "/var/log/cloud-init-was.log" ]; then echo false; else echo true; fi')
-            if [[ $isCloudInitReady = false ]]; then
-              echo "waiting for was entitlement/evaluation check started..."
-              sleep 5
-            else
-              echo "was entitlement/evaluation check started..."
-            fi
-          done
-
-          isDone=false
-          while [ $isDone = false ]
-          do
-            result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} '(tail -n1) </var/log/cloud-init-was.log')
-            # Remove special characters
-            result=$(echo $result | sed $'s/[^[:alnum:]\t]//g')
-            if [[ "$result" == "Unentitled" ]] || [[ "$result" == "Entitled" ]] || [[ "$result" == "Undefined" ]] || [[ "$result" = "Evaluation" ]]; then
-                isDone=true
-            else
-                echo "waiting for was entitlement/evaluation check completed..."
-                sleep 5
-            fi
-          done
-          echo $result
-
-          if [ ${result} != Entitled ]; then
-              exit 1
-          fi
-          
-          # Check the installation path is removed
-          echo "Check the installation path is removed"
-          pathExists=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} 'if [ -d "${{ env.was_nd_install_directory }}" ]; then echo true; else echo false; fi')
-          if [[ $pathExists = false ]]; then
-            echo "IBM installations do not exist"
-            exit 1
-          fi
+              --parameters scriptLocation=${{ env.scriptLocation }} deploymentMode=Entitled ibmUserId=${{ env.entitledIbmUserId }} ibmUserPwd=${{ env.entitledIbmPassword }} vmName=entitled${{ github.run_id }}${{ github.run_number }} vmAdminId=${{ env.vmAdminId }} vmAdminPwd=${{ env.vmAdminPassword }} location=${{ env.location }} imageResourceId=$imageResourceId
       - name: Deploy VM using image for evaluation usage
         run: |
           imageResourceId=$(az image show --name ${{ env.vmName }} --resource-group ${{ env.testResourceGroup }} --query id -o tsv)
@@ -292,57 +186,7 @@ jobs:
           az deployment group create --resource-group ${{ env.testResourceGroup }} \
               --name evaluation${{ github.run_id }}${{ github.run_number }} \
               --template-file ./mainTemplate.json \
-              --parameters ibmUserId="" ibmUserPwd="" vmName=evaluation${{ github.run_id }}${{ github.run_number }} vmAdminId=${{ env.vmAdminId }} vmAdminPwd=${{ env.vmAdminPassword }} location=${{ env.location }} imageResourceId=$imageResourceId
-      - name: Verify the IBM installations for evaluation usage
-        run: |
-          echo "query public ip"
-          evaluationVMIP=$(az vm show \
-            --resource-group ${{ env.testResourceGroup }} \
-            --name evaluation${{ github.run_id }}${{ github.run_number }} -d \
-            --query publicIps -o tsv)
-          echo "pubilc IP of VM: ${evaluationVMIP}"
-          echo "Verifying WebSphere server installation"
-          echo install sshpass
-          sudo apt-get install -y sshpass
-          timeout 1m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${evaluationVMIP} 22
-          isCloudInitReady=false
-          while [ $isCloudInitReady = false ]
-          do
-            isCloudInitReady=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${evaluationVMIP} 'if [ ! -f "/var/log/cloud-init-was.log" ]; then echo false; else echo true; fi')
-            if [[ $isCloudInitReady = false ]]; then
-              echo "waiting for entitlement/evaluation check started..."
-              sleep 5
-            else
-              echo "entitlement/evaluation check started..."
-            fi
-          done
-
-          isDone=false
-          while [ $isDone = false ]
-          do
-            result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${evaluationVMIP} '(tail -n1) </var/log/cloud-init-was.log')
-            # Remove special characters
-            result=$(echo $result | sed $'s/[^[:alnum:]\t]//g')
-            if [[ "$result" == "Unentitled" ]] || [[ "$result" == "Entitled" ]] || [[ "$result" == "Undefined" ]] || [[ "$result" = "Evaluation" ]]; then
-                isDone=true
-            else
-                echo "waiting for entitlement/evaluation check completed..."
-                sleep 5
-            fi
-          done
-          echo $result
-
-          if [ ${result} != Evaluation ]; then
-              exit 1
-          fi
-          
-          # Check the installation path exists
-          echo "Check the installation path exists"
-          pathExists=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${evaluationVMIP} 'if [ -d "${{ env.was_nd_install_directory }}" ]; then echo true; else echo false; fi')
-          if [[ $pathExists = false ]]; then
-            echo "IBM installations do not exist"
-            exit 1
-          fi
+              --parameters scriptLocation=${{ env.scriptLocation }} deploymentMode=Evaluation ibmUserId="" ibmUserPwd="" vmName=evaluation${{ github.run_id }}${{ github.run_number }} vmAdminId=${{ env.vmAdminId }} vmAdminPwd=${{ env.vmAdminPassword }} location=${{ env.location }} imageResourceId=$imageResourceId
       - name: Generate SAS url
         id: generate-sas-blob-url
         run: |

--- a/ihs/test/check.sh
+++ b/ihs/test/check.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+#      Copyright (c) Microsoft Corporation.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+# 
+#           http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Deployment mode: Entitled, Unentitled or Evaluation
+deploymentMode=$1
+echo "The input deployment mode to be verified is ${deploymentMode}."
+
+# Get tWAS installation properties
+source /datadrive/virtualimage.properties
+
+# Wait until entitlement/evaluation check started
+while [ ! -f "$WAS_LOG_PATH" ]
+do
+    echo "Waiting for entitlement/evaluation check started..."
+    sleep 5
+done
+
+# Wait until entitlement/evaluation check completed
+isDone=false
+while [ $isDone = false ]
+do
+    result=`(tail -n1) <$WAS_LOG_PATH`
+    if [[ $result = $ENTITLED ]] || [[ $result = $UNENTITLED ]] || [[ $result = $UNDEFINED ]] || [[ $result = $EVALUATION ]]; then
+        isDone=true
+    else
+        echo "Waiting for entitlement/evaluation check completed..."
+        sleep 5
+    fi
+done
+
+# Check if the entitlement/evaluation check result matches with the input deployment mode
+echo "The entitlement/evaluation check result is ${result}."
+if [ ${deploymentMode} != ${result} ]; then
+    echo "The entitlement/evaluation check result (${result}) doesn't match with the input deployment mode (${deploymentMode})."
+    exit 1
+fi
+
+# Check installation exists or not
+if [ ${deploymentMode} != $UNENTITLED ]; then
+    ${IHS_INSTALL_DIRECTORY}/bin/versionInfo.sh
+    ${PLUGIN_INSTALL_DIRECTORY}/bin/versionInfo.sh
+    ${WCT_INSTALL_DIRECTORY}/bin/versionInfo.sh
+elif [ -d ${IHS_INSTALL_DIRECTORY}/bin ] || [ -d ${PLUGIN_INSTALL_DIRECTORY}/bin ] || [ -d ${WCT_INSTALL_DIRECTORY}/bin ]; then
+    echo "The installation directory still exists, it should be removed for the unentitled user."
+    exit 1
+else
+    echo "The installation is successfully removed for the unentitled user."
+fi

--- a/ihs/test/mainTemplate.json
+++ b/ihs/test/mainTemplate.json
@@ -6,6 +6,17 @@
             "type": "string",
             "defaultValue": "[resourceGroup().location]"
         },
+        "deploymentMode": {
+            "type": "string",
+            "allowedValues": [
+                "Entitled",
+                "Unentitled",
+                "Evaluation"
+            ]
+        },
+        "scriptLocation": {
+            "type": "string"
+        },
         "dnsLabelPrefix": {
             "defaultValue": "wsp",
             "type": "string"
@@ -67,20 +78,6 @@
     },
     "resources": [
         {
-            "apiVersion": "2019-09-01",
-            "name": "testtargetdpeloymentstart",
-            "type": "Microsoft.Resources/deployments",
-            "properties": {
-                "mode": "Incremental",
-                "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-                    "contentVersion": "1.0.0.0",
-                    "resources": [
-                    ]
-                }
-            }
-        },
-        {
             "type": "Microsoft.Network/networkSecurityGroups",
             "apiVersion": "2019-06-01",
             "name": "[variables('name_networkSecurityGroup')]",
@@ -137,7 +134,7 @@
                     "id": "[variables('ref_networkSecurityGroup')]"
                 }
             }
-        },                
+        },
         {
             "type": "Microsoft.Network/publicIPAddresses",
             "apiVersion": "2019-06-01",
@@ -208,6 +205,27 @@
                             "id": "[variables('ref_networkInterface')]"
                         }
                     ]
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "apiVersion": "2020-06-01",
+            "name": "[concat(variables('name_virtualMachine'), '/CustomScript')]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Compute/virtualMachines', variables('name_virtualMachine'))]"
+            ],
+            "properties": {
+                "autoUpgradeMinorVersion": true,
+                "publisher": "Microsoft.Azure.Extensions",
+                "type": "CustomScript",
+                "typeHandlerVersion": "2.0",
+                "settings": {
+                    "fileUris": [
+                        "[uri(parameters('scriptLocation'), 'check.sh')]"
+                    ],
+                    "commandToExecute": "[concat('sh check.sh ', parameters('deploymentMode'))]"
                 }
             }
         }

--- a/twas-base/test/check.sh
+++ b/twas-base/test/check.sh
@@ -16,6 +16,7 @@
 
 # Deployment mode: Entitled, Unentitled or Evaluation
 deploymentMode=$1
+echo "The input deployment mode to be verified is ${deploymentMode}."
 
 # Get tWAS installation properties
 source /datadrive/virtualimage.properties
@@ -40,9 +41,10 @@ do
     fi
 done
 
-# Check if the entitlement check result matches with the input deployment mode
-if [ ${result} != ${deploymentMode} ]; then
-    echo "The entitlement check result (${result}) doesn't match with the input deployment mode (${deploymentMode})."
+# Check if the entitlement/evaluation check result matches with the input deployment mode
+echo "The entitlement/evaluation check result is ${result}."
+if [ ${deploymentMode} != ${result} ]; then
+    echo "The entitlement/evaluation check result (${result}) doesn't match with the input deployment mode (${deploymentMode})."
     exit 1
 fi
 
@@ -53,5 +55,5 @@ elif [ -d ${WAS_BASE_INSTALL_DIRECTORY}/bin ]; then
     echo "The installation directory still exists, it should be removed for the unentitled user."
     exit 1
 else
-    echo "The installation is removed for the unentitled user."
+    echo "The installation is successfully removed for the unentitled user."
 fi

--- a/twas-base/test/check.sh
+++ b/twas-base/test/check.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+
+#      Copyright (c) Microsoft Corporation.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+# 
+#           http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Deployment mode: Entitled, Unentitled or Evaluation
+deploymentMode=$1
+
+# Get tWAS installation properties
+source /datadrive/virtualimage.properties
+
+# Wait until entitlement/evaluation check started
+while [ ! -f "$WAS_LOG_PATH" ]
+do
+    echo "Waiting for entitlement/evaluation check started..."
+    sleep 5
+done
+
+# Wait until entitlement/evaluation check completed
+isDone=false
+while [ $isDone = false ]
+do
+    result=`(tail -n1) <$WAS_LOG_PATH`
+    if [[ $result = $ENTITLED ]] || [[ $result = $UNENTITLED ]] || [[ $result = $UNDEFINED ]] || [[ $result = $EVALUATION ]]; then
+        isDone=true
+    else
+        echo "Waiting for entitlement/evaluation check completed..."
+        sleep 5
+    fi
+done
+
+# Check if the entitlement check result matches with the input deployment mode
+if [ ${result} != ${deploymentMode} ]; then
+    echo "The entitlement check result (${result}) doesn't match with the input deployment mode (${deploymentMode})."
+    exit 1
+fi
+
+# Check installation exists or not
+if [ ${deploymentMode} != $UNENTITLED ]; then
+    ${WAS_BASE_INSTALL_DIRECTORY}/bin/versionInfo.sh
+elif [ -d ${WAS_BASE_INSTALL_DIRECTORY}/bin ]; then
+    echo "The installation directory still exists, it should be removed for the unentitled user."
+    exit 1
+else
+    echo "The installation is removed for the unentitled user."
+fi

--- a/twas-base/test/mainTemplate.json
+++ b/twas-base/test/mainTemplate.json
@@ -95,11 +95,7 @@
                             "priority": 320,
                             "direction": "Inbound",
                             "destinationPortRanges": [
-                                "22",
-                                "9043",
-                                "9060",
-                                "9080",
-                                "9443"
+                                "22"
                             ]
                         }
                     }

--- a/twas-base/test/mainTemplate.json
+++ b/twas-base/test/mainTemplate.json
@@ -10,7 +10,7 @@
             "type": "string",
             "allowedValues": [
                 "Entitled",
-                "Undefined",
+                "Unentitled",
                 "Evaluation"
             ]
         },

--- a/twas-base/test/mainTemplate.json
+++ b/twas-base/test/mainTemplate.json
@@ -6,6 +6,17 @@
             "type": "string",
             "defaultValue": "[resourceGroup().location]"
         },
+        "deploymentMode": {
+            "type": "string",
+            "allowedValues": [
+                "Entitled",
+                "Undefined",
+                "Evaluation"
+            ]
+        },
+        "scriptLocation": {
+            "type": "string"
+        },
         "dnsLabelPrefix": {
             "defaultValue": "wsp",
             "type": "string"
@@ -198,6 +209,27 @@
                             "id": "[variables('ref_networkInterface')]"
                         }
                     ]
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "apiVersion": "2020-06-01",
+            "name": "[concat(variables('name_virtualMachine'), '/CustomScript')]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Compute/virtualMachines', variables('name_virtualMachine'))]"
+            ],
+            "properties": {
+                "autoUpgradeMinorVersion": true,
+                "publisher": "Microsoft.Azure.Extensions",
+                "type": "CustomScript",
+                "typeHandlerVersion": "2.0",
+                "settings": {
+                    "fileUris": [
+                        "[uri(parameters('scriptLocation'), 'check.sh')]"
+                    ],
+                    "commandToExecute": "[concat('sh check.sh ', parameters('deploymentMode'))]"
                 }
             }
         }

--- a/twas-nd/test/check.sh
+++ b/twas-nd/test/check.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+
+#      Copyright (c) Microsoft Corporation.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+# 
+#           http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Deployment mode: Entitled, Unentitled or Evaluation
+deploymentMode=$1
+echo "The input deployment mode to be verified is ${deploymentMode}."
+
+# Get tWAS installation properties
+source /datadrive/virtualimage.properties
+
+# Wait until entitlement/evaluation check started
+while [ ! -f "$WAS_LOG_PATH" ]
+do
+    echo "Waiting for entitlement/evaluation check started..."
+    sleep 5
+done
+
+# Wait until entitlement/evaluation check completed
+isDone=false
+while [ $isDone = false ]
+do
+    result=`(tail -n1) <$WAS_LOG_PATH`
+    if [[ $result = $ENTITLED ]] || [[ $result = $UNENTITLED ]] || [[ $result = $UNDEFINED ]] || [[ $result = $EVALUATION ]]; then
+        isDone=true
+    else
+        echo "Waiting for entitlement/evaluation check completed..."
+        sleep 5
+    fi
+done
+
+# Check if the entitlement/evaluation check result matches with the input deployment mode
+echo "The entitlement/evaluation check result is ${result}."
+if [ ${deploymentMode} != ${result} ]; then
+    echo "The entitlement/evaluation check result (${result}) doesn't match with the input deployment mode (${deploymentMode})."
+    exit 1
+fi
+
+# Check installation exists or not
+if [ ${deploymentMode} != $UNENTITLED ]; then
+    ${WAS_ND_INSTALL_DIRECTORY}/bin/versionInfo.sh
+elif [ -d ${WAS_ND_INSTALL_DIRECTORY}/bin ]; then
+    echo "The installation directory still exists, it should be removed for the unentitled user."
+    exit 1
+else
+    echo "The installation is successfully removed for the unentitled user."
+fi

--- a/twas-nd/test/mainTemplate.json
+++ b/twas-nd/test/mainTemplate.json
@@ -95,11 +95,7 @@
                             "priority": 320,
                             "direction": "Inbound",
                             "destinationPortRanges": [
-                                "22",
-                                "9043",
-                                "9060",
-                                "9080",
-                                "9443"
+                                "22"
                             ]
                         }
                     }

--- a/twas-nd/test/mainTemplate.json
+++ b/twas-nd/test/mainTemplate.json
@@ -6,6 +6,17 @@
             "type": "string",
             "defaultValue": "[resourceGroup().location]"
         },
+        "deploymentMode": {
+            "type": "string",
+            "allowedValues": [
+                "Entitled",
+                "Unentitled",
+                "Evaluation"
+            ]
+        },
+        "scriptLocation": {
+            "type": "string"
+        },
         "dnsLabelPrefix": {
             "defaultValue": "wsp",
             "type": "string"
@@ -67,20 +78,6 @@
     },
     "resources": [
         {
-            "apiVersion": "2019-09-01",
-            "name": "testtargetdpeloymentstart",
-            "type": "Microsoft.Resources/deployments",
-            "properties": {
-                "mode": "Incremental",
-                "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-                    "contentVersion": "1.0.0.0",
-                    "resources": [
-                    ]
-                }
-            }
-        },
-        {
             "type": "Microsoft.Network/networkSecurityGroups",
             "apiVersion": "2019-06-01",
             "name": "[variables('name_networkSecurityGroup')]",
@@ -141,7 +138,7 @@
                     "id": "[variables('ref_networkSecurityGroup')]"
                 }
             }
-        },                
+        },
         {
             "type": "Microsoft.Network/publicIPAddresses",
             "apiVersion": "2019-06-01",
@@ -214,12 +211,27 @@
                     ]
                 }
             }
+        },
+        {
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "apiVersion": "2020-06-01",
+            "name": "[concat(variables('name_virtualMachine'), '/CustomScript')]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Compute/virtualMachines', variables('name_virtualMachine'))]"
+            ],
+            "properties": {
+                "autoUpgradeMinorVersion": true,
+                "publisher": "Microsoft.Azure.Extensions",
+                "type": "CustomScript",
+                "typeHandlerVersion": "2.0",
+                "settings": {
+                    "fileUris": [
+                        "[uri(parameters('scriptLocation'), 'check.sh')]"
+                    ],
+                    "commandToExecute": "[concat('sh check.sh ', parameters('deploymentMode'))]"
+                }
+            }
         }
-    ],
-    "outputs": {
-        "adminSecuredConsole": {
-            "type": "string",
-            "value": "[concat('https://',reference(variables('name_publicIPAddress')).dnsSettings.fqdn,':9043/ibm/console')]"
-        }
-    }
+    ]
 }


### PR DESCRIPTION
The PR is to fix WASdev/azure.websphere-traditional.cluster/issues/163 which complains the intermittent failure of base image building pipelines.

The failure happened when the pipeline tried to execute the following command remotely in the VM using `ssh`:
```
result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${entitledVMIP} '(tail -n1) </var/log/cloud-init-was.log')
```

Per investigation and testing, the root cause is most probably that too many ssh connections are initiated in a short time window in [while loops](https://github.com/WASdev/azure.websphere-traditional.image/blob/main/.github/workflows/twas-baseBuild.yml#L249-L272).

The PR is to get rid of these ssh connections by moving the verification logic into the script which will be executed as the custom extension script of the VM. It also removes the duplicated code from pipeline workflow files, as a side effect.

The code changes are verified that the intermittent failure of pipelines is not observed during the testing.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>