### PR TITLE
BVN: Azure WAS VM image partner-center.html updates

### DIFF
--- a/ihs/src/main/resources/marketing-artifacts/partner-center.html
+++ b/ihs/src/main/resources/marketing-artifacts/partner-center.html
@@ -36,8 +36,8 @@ Program managers, architects and engineers will reach back out to you shortly an
 <ul>
 <li><a href="https://learn.microsoft.com/en-us/azure/developer/java/ee/websphere-family">WebSphere on Azure</a></li>
 <li><a href="https://ibm.biz/WebSphereOnAzureContactMe">IBM WebSphere Product Family on Azure</a></li>
-<li><a href="https://aka.ms/twas-ND-portal">WebSphere ND Image on Azure VM</a></li>
-<li><a href="https://aka.ms/twas-Base-portal">WebSphere Base Image on Azure VM</a></li>
+<li><a href="https://ibm.biz/twas-ND-portal">WebSphere ND Image on Azure VM</a></li>
+<li><a href="https://ibm.biz/twas-Base-portal">WebSphere Base Image on Azure VM</a></li>
 <li><a href="https://aka.ms/twas-single-portal">WebSphere Single Instance on Azure VM</a></li>
 <li><a href="https://aka.ms/twas-cluster-portal">WebSphere Cluster on Azure VMs</a></li>
 <li><a href="https://aka.ms/liberty-aro">WebSphere Liberty/Open Liberty on ARO</a></li>

--- a/ihs/src/main/resources/marketing-artifacts/partner-center.html
+++ b/ihs/src/main/resources/marketing-artifacts/partner-center.html
@@ -41,5 +41,5 @@ Program managers, architects and engineers will reach back out to you shortly an
 <li><a href="https://aka.ms/twas-single-portal">WebSphere Single Instance on Azure VM</a></li>
 <li><a href="https://aka.ms/twas-cluster-portal">WebSphere Cluster on Azure VMs</a></li>
 <li><a href="https://aka.ms/liberty-aro">WebSphere Liberty/Open Liberty on ARO</a></li>
-<li><a href="https://aka.ms/liberty-aks">WebSphere Liberty/Open Liberty on AKS</a></li>
+<li><a href="https://ibm.biz/liberty-aks">WebSphere Liberty/Open Liberty on AKS</a></li>
 </ul>

--- a/ihs/src/main/resources/marketing-artifacts/partner-center.html
+++ b/ihs/src/main/resources/marketing-artifacts/partner-center.html
@@ -36,8 +36,8 @@ Program managers, architects and engineers will reach back out to you shortly an
 <ul>
 <li><a href="https://learn.microsoft.com/en-us/azure/developer/java/ee/websphere-family">WebSphere on Azure</a></li>
 <li><a href="https://ibm.biz/WebSphereOnAzureContactMe">IBM WebSphere Product Family on Azure</a></li>
-<li><a href="https://ibm.biz/twas-ND-portal">WebSphere ND Image on Azure VM</a></li>
-<li><a href="https://ibm.biz/twas-Base-portal">WebSphere Base Image on Azure VM</a></li>
+<li><a href="https://ibm.biz/twas-nc-portal">WebSphere ND Image on Azure VM</a></li>
+<li><a href="https://ibm.biz/twas-base-portal">WebSphere Base Image on Azure VM</a></li>
 <li><a href="https://aka.ms/twas-single-portal">WebSphere Single Instance on Azure VM</a></li>
 <li><a href="https://aka.ms/twas-cluster-portal">WebSphere Cluster on Azure VMs</a></li>
 <li><a href="https://aka.ms/liberty-aro">WebSphere Liberty/Open Liberty on ARO</a></li>

--- a/ihs/src/main/resources/marketing-artifacts/partner-center.html
+++ b/ihs/src/main/resources/marketing-artifacts/partner-center.html
@@ -1,16 +1,16 @@
 <h1>Azure Virtual Machine Offer</h1>
 <h2>Offer setup</h2>
 <h3>Alias</h3>
-<p>IBM HTTP Server for WebSphere Application Server 9.0.5.x IHS Image and JDK 8 on RHEL 9.x</p>
+<p>IBM HTTP Server for WebSphere Application Server 9.0.5.x Image and JDK 8 on RHEL 9.x</p>
 <h2>Offer listing</h2>
 <h3>Name</h3>
-<p>IBM HTTP Server for WebSphere Application Server 9.0.5.x IHS Image and JDK 8 on RHEL 9.x</p>
+<p>IBM HTTP Server for WebSphere Application Server 9.0.5.x Image and JDK 8 on RHEL 9.x</p>
 <h3>Search results summary</h3>
-<p>IBM HTTP Server for WebSphere Application Server 9.0.5.x IHS Image and JDK 8 on RHEL 9.x</p>
+<p>IBM HTTP Server for WebSphere Application Server 9.0.5.x Image and JDK 8 on RHEL 9.x</p>
 <h3>Short description</h3>
-<p>IBM HTTP Server for WebSphere Application Server 9.0.5.x IHS Image and JDK 8 on Red Hat Enterprise Linux 9.x.</p>
+<p>IBM HTTP Server for WebSphere Application Server 9.0.5.x Image and JDK 8 on Red Hat Enterprise Linux 9.x.</p>
 <h3>Description</h3>
-<p>This is an IBM HTTP Server for WebSphere Application Server 9.0.5.x IHS image and JDK 8 with Red Hat Enterprise Linux 9.x.</p>
+<p>This is an IBM HTTP Server for WebSphere Application Server 9.0.5.x Image and JDK 8 with Red Hat Enterprise Linux 9.x.</p>
 <p>The VM instance created by this offer is suitable for customers that require very highly customized Azure deployments. 
 Users of this offer are expected to be familiar with WebSphere Application Server administration. The VM is installed with
 the specified GNU/Linux distribution, IBM JDK version, and IBM HTTP Server for WebSphere Application Server version. 

--- a/ihs/src/main/resources/marketing-artifacts/partner-center.html
+++ b/ihs/src/main/resources/marketing-artifacts/partner-center.html
@@ -1,16 +1,16 @@
 <h1>Azure Virtual Machine Offer</h1>
 <h2>Offer setup</h2>
 <h3>Alias</h3>
-<p>IBM HTTP Server for WebSphere Application Server 9.0.5.x Base Image and JDK 8 on RHEL 9.x</p>
+<p>IBM HTTP Server for WebSphere Application Server 9.0.5.x IHS Image and JDK 8 on RHEL 9.x</p>
 <h2>Offer listing</h2>
 <h3>Name</h3>
-<p>IBM HTTP Server for WebSphere Application Server 9.0.5.x Base Image and JDK 8 on RHEL 9.x</p>
+<p>IBM HTTP Server for WebSphere Application Server 9.0.5.x IHS Image and JDK 8 on RHEL 9.x</p>
 <h3>Search results summary</h3>
-<p>IBM HTTP Server for WebSphere Application Server 9.0.5.x Base Image and JDK 8 on RHEL 9.x</p>
+<p>IBM HTTP Server for WebSphere Application Server 9.0.5.x IHS Image and JDK 8 on RHEL 9.x</p>
 <h3>Short description</h3>
-<p>IBM HTTP Server for WebSphere Application Server 9.0.5.x Base Image and JDK 8 on Red Hat Enterprise Linux 9.x.</p>
+<p>IBM HTTP Server for WebSphere Application Server 9.0.5.x IHS Image and JDK 8 on Red Hat Enterprise Linux 9.x.</p>
 <h3>Description</h3>
-<p>This is an IBM HTTP Server for WebSphere Application Server 9.0.5.x base image and JDK 8 with Red Hat Enterprise Linux 9.x.</p>
+<p>This is an IBM HTTP Server for WebSphere Application Server 9.0.5.x IHS image and JDK 8 with Red Hat Enterprise Linux 9.x.</p>
 <p>The VM instance created by this offer is suitable for customers that require very highly customized Azure deployments. 
 Users of this offer are expected to be familiar with WebSphere Application Server administration. The VM is installed with
 the specified GNU/Linux distribution, IBM JDK version, and IBM HTTP Server for WebSphere Application Server version. 
@@ -24,9 +24,10 @@ The relevant directories are listed here:</p>
 <li>WCT_JAVA_HOME: ${WCT_INSTALL_ROOT}/java/8.0</li>
 </ul>
 <p>There is no pre-configured IBM HTTP Server for WebSphere Application Server. During VM creation, you are asked to provide a username and SSH key or credentials for the admin account.
-After logging in with this account, do sudo -i to get write access to the relevant directories.</p>
-<p>In addition to the VM base image, offers also include different solution templates to meet different scenarios on virtual machines, AKS and ARO such as 
-WebSphere Sever Single Instance/Cluster and WebSphere Liberty/Open Liberty on AKS/ARO. These offers are linked in the <i>Learn more</i> section at the bottom of the
+After logging in with this account, do <code>sudo -i</code> to get write access to the relevant directories.</p>
+<p>In addition to the VM ihs image, other offers are available to meet different needs.  These includes solution templates for 
+    WebSphere Application Server Single Instance or Cluster in virtual machines and WebSphere Liberty/Open Liberty on AKS or ARO. 
+    These offers are linked in the <i>Learn more</i> section at the bottom of the
 <a href="https://ibm.biz/WebSphereOnAzureContactMe">IBM WebSphere Product Family on Azure</a> page.</p>
 <p>If you want to work closely on your migration scenarios with the engineering team developing these offers, just click the CONTACT ME button on the
 <a href="https://ibm.biz/WebSphereOnAzureContactMe">IBM WebSphere Product Family on Azure</a> page.
@@ -35,6 +36,8 @@ Program managers, architects and engineers will reach back out to you shortly an
 <ul>
 <li><a href="https://learn.microsoft.com/en-us/azure/developer/java/ee/websphere-family">WebSphere on Azure</a></li>
 <li><a href="https://ibm.biz/WebSphereOnAzureContactMe">IBM WebSphere Product Family on Azure</a></li>
+<li><a href="https://aka.ms/twas-ND-portal">WebSphere ND Image on Azure VM</a></li>
+<li><a href="https://aka.ms/twas-Base-portal">WebSphere Base Image on Azure VM</a></li>
 <li><a href="https://aka.ms/twas-single-portal">WebSphere Single Instance on Azure VM</a></li>
 <li><a href="https://aka.ms/twas-cluster-portal">WebSphere Cluster on Azure VMs</a></li>
 <li><a href="https://aka.ms/liberty-aro">WebSphere Liberty/Open Liberty on ARO</a></li>

--- a/twas-base/src/main/resources/marketing-artifacts/partner-center.html
+++ b/twas-base/src/main/resources/marketing-artifacts/partner-center.html
@@ -1,16 +1,16 @@
 <h1>Azure Virtual Machine Offer</h1>
 <h2>Offer setup</h2>
 <h3>Alias</h3>
-<p>IBM WebSphere Application Server Base 9.0.5.x Base Image and JDK 8 on RHEL 9.x</p>
+<p>IBM WebSphere Application Server Base 9.0.5.x Image and JDK 8 on RHEL 9.x</p>
 <h2>Offer listing</h2>
 <h3>Name</h3>
-<p>IBM WebSphere Application Server Base 9.0.5.x Base Image and JDK 8 on RHEL 9.x</p>
+<p>IBM WebSphere Application Server Base 9.0.5.x Image and JDK 8 on RHEL 9.x</p>
 <h3>Search results summary</h3>
-<p>IBM WebSphere Application Server Base 9.0.5.x Base Image and JDK 8 on Red Hat Enterprise Linux 9.x</p>
+<p>IBM WebSphere Application Server Base 9.0.5.x Image and JDK 8 on Red Hat Enterprise Linux 9.x</p>
 <h3>Short description</h3>
-<p>IBM WebSphere Application Server Base 9.0.5.x Base Image and JDK 8 on Red Hat Enterprise Linux 9.x.</p>
+<p>IBM WebSphere Application Server Base 9.0.5.x Image and JDK 8 on Red Hat Enterprise Linux 9.x.</p>
 <h3>Description</h3>
-<p>This is an IBM WebSphere Application Server Base 9.0.5.x base image and JDK 8 with Red Hat Enterprise Linux 9.x.</p>
+<p>This is an IBM WebSphere Application Server Base 9.0.5.x Image and JDK 8 with Red Hat Enterprise Linux 9.x.</p>
 <p>The VM instance created by this offer is suitable for customers that require very highly customized Azure deployments. 
 Users of this offer are expected to be familiar with WebSphere Application Server administration. The VM is installed with
 the specified GNU/Linux distribution, IBM JDK version, and WebSphere Application Server Base Deployment version. 
@@ -21,7 +21,7 @@ The relevant directories are listed here:</p>
 </ul>
 <p>There is no pre-created server instance. During VM creation, you are asked to provide a username and SSH key or credentials for the admin account.
 After logging in with this account, do <code>sudo -i</code> to get write access to the relevant directories.</p>
-<p>In addition to the VM base image, other offers are available to meet different needs.  These includes solution templates for 
+<p>In addition to the VM base Image, other offers are available to meet different needs.  These includes solution templates for 
 WebSphere Application Server Single Instance or Cluster in virtual machines and WebSphere Liberty/Open Liberty on AKS or ARO. 
 These offers are linked in the <i>Learn more</i> section at the bottom of the
 <a href="https://ibm.biz/WebSphereOnAzureContactMe">IBM WebSphere Product Family on Azure</a> page.</p>

--- a/twas-base/src/main/resources/marketing-artifacts/partner-center.html
+++ b/twas-base/src/main/resources/marketing-artifacts/partner-center.html
@@ -32,8 +32,8 @@ Program managers, architects and engineers will reach back out to you shortly an
 <ul>
 <li><a href="https://learn.microsoft.com/en-us/azure/developer/java/ee/websphere-family">WebSphere on Azure</a></li>
 <li><a href="https://ibm.biz/WebSphereOnAzureContactMe">IBM WebSphere Product Family on Azure</a></li>
-<li><a href="https://ibm.biz/twas-ND-portal">WebSphere ND Image on Azure VM</a></li>
-<li><a href="https://ibm.biz/twas-IHS-portal">WebSphere IHS Image on Azure VM</a></li>
+<li><a href="https://ibm.biz/twas-nd-portal">WebSphere ND Image on Azure VM</a></li>
+<li><a href="https://ibm.biz/twas-ihs-portal">WebSphere IHS Image on Azure VM</a></li>
 <li><a href="https://aka.ms/twas-single-portal">WebSphere Single Instance on Azure VM</a></li>
 <li><a href="https://aka.ms/twas-cluster-portal">WebSphere Cluster on Azure VMs</a></li>
 <li><a href="https://aka.ms/liberty-aro">WebSphere Liberty/Open Liberty on ARO</a></li>

--- a/twas-base/src/main/resources/marketing-artifacts/partner-center.html
+++ b/twas-base/src/main/resources/marketing-artifacts/partner-center.html
@@ -32,8 +32,8 @@ Program managers, architects and engineers will reach back out to you shortly an
 <ul>
 <li><a href="https://learn.microsoft.com/en-us/azure/developer/java/ee/websphere-family">WebSphere on Azure</a></li>
 <li><a href="https://ibm.biz/WebSphereOnAzureContactMe">IBM WebSphere Product Family on Azure</a></li>
-<li><a href="https://aka.ms/twas-ND-portal">WebSphere ND Image on Azure VM</a></li>
-<li><a href="https://aka.ms/twas-IHS-portal">WebSphere IHS Image on Azure VM</a></li>
+<li><a href="https://ibm.biz/twas-ND-portal">WebSphere ND Image on Azure VM</a></li>
+<li><a href="https://ibm.biz/twas-IHS-portal">WebSphere IHS Image on Azure VM</a></li>
 <li><a href="https://aka.ms/twas-single-portal">WebSphere Single Instance on Azure VM</a></li>
 <li><a href="https://aka.ms/twas-cluster-portal">WebSphere Cluster on Azure VMs</a></li>
 <li><a href="https://aka.ms/liberty-aro">WebSphere Liberty/Open Liberty on ARO</a></li>

--- a/twas-base/src/main/resources/marketing-artifacts/partner-center.html
+++ b/twas-base/src/main/resources/marketing-artifacts/partner-center.html
@@ -13,16 +13,17 @@
 <p>This is an IBM WebSphere Application Server Base 9.0.5.x base image and JDK 8 with Red Hat Enterprise Linux 9.x.</p>
 <p>The VM instance created by this offer is suitable for customers that require very highly customized Azure deployments. 
 Users of this offer are expected to be familiar with WebSphere Application Server administration. The VM is installed with
-the specified GNU/Linux distribution, IBM JDK version, and WebSphere Application Server Network Deployment version. 
+the specified GNU/Linux distribution, IBM JDK version, and WebSphere Application Server Base Deployment version. 
 The relevant directories are listed here:</p>
 <ul>
 <li>WAS_INSTALL_ROOT: /datadrive/IBM/WebSphere/Base/V9</li>
 <li>JAVA_HOME: ${WAS_INSTALL_ROOT}/java/8.0</li>
 </ul>
 <p>There is no pre-created server instance. During VM creation, you are asked to provide a username and SSH key or credentials for the admin account.
-After logging in with this account, do sudo -i to get write access to the relevant directories.</p>
-<p>In addition to the VM base image, offers also include different solution templates to meet different scenarios on virtual machines, AKS and ARO such as 
-WebSphere Sever Single Instance/Cluster and WebSphere Liberty/Open Liberty on AKS/ARO. These offers are linked in the <i>Learn more</i> section at the bottom of the
+After logging in with this account, do <code>sudo -i</code> to get write access to the relevant directories.</p>
+<p>In addition to the VM base image, other offers are available to meet different needs.  These includes solution templates for 
+WebSphere Application Server Single Instance or Cluster in virtual machines and WebSphere Liberty/Open Liberty on AKS or ARO. 
+These offers are linked in the <i>Learn more</i> section at the bottom of the
 <a href="https://ibm.biz/WebSphereOnAzureContactMe">IBM WebSphere Product Family on Azure</a> page.</p>
 <p>If you want to work closely on your migration scenarios with the engineering team developing these offers, just click the CONTACT ME button on the
 <a href="https://ibm.biz/WebSphereOnAzureContactMe">IBM WebSphere Product Family on Azure</a> page.
@@ -31,6 +32,8 @@ Program managers, architects and engineers will reach back out to you shortly an
 <ul>
 <li><a href="https://learn.microsoft.com/en-us/azure/developer/java/ee/websphere-family">WebSphere on Azure</a></li>
 <li><a href="https://ibm.biz/WebSphereOnAzureContactMe">IBM WebSphere Product Family on Azure</a></li>
+<li><a href="https://aka.ms/twas-ND-portal">WebSphere ND Image on Azure VM</a></li>
+<li><a href="https://aka.ms/twas-IHS-portal">WebSphere IHS Image on Azure VM</a></li>
 <li><a href="https://aka.ms/twas-single-portal">WebSphere Single Instance on Azure VM</a></li>
 <li><a href="https://aka.ms/twas-cluster-portal">WebSphere Cluster on Azure VMs</a></li>
 <li><a href="https://aka.ms/liberty-aro">WebSphere Liberty/Open Liberty on ARO</a></li>

--- a/twas-base/src/main/resources/marketing-artifacts/partner-center.html
+++ b/twas-base/src/main/resources/marketing-artifacts/partner-center.html
@@ -37,5 +37,5 @@ Program managers, architects and engineers will reach back out to you shortly an
 <li><a href="https://aka.ms/twas-single-portal">WebSphere Single Instance on Azure VM</a></li>
 <li><a href="https://aka.ms/twas-cluster-portal">WebSphere Cluster on Azure VMs</a></li>
 <li><a href="https://aka.ms/liberty-aro">WebSphere Liberty/Open Liberty on ARO</a></li>
-<li><a href="https://aka.ms/liberty-aks">WebSphere Liberty/Open Liberty on AKS</a></li>
+<li><a href="https://ibm.biz/liberty-aks">WebSphere Liberty/Open Liberty on AKS</a></li>
 </ul>

--- a/twas-nd/src/main/resources/marketing-artifacts/partner-center.html
+++ b/twas-nd/src/main/resources/marketing-artifacts/partner-center.html
@@ -1,16 +1,16 @@
 <h1>Azure Virtual Machine Offer</h1>
 <h2>Offer setup</h2>
 <h3>Alias</h3>
-<p>IBM WebSphere Application Server ND 9.0.5.x Base Image and JDK 8 on RHEL 9.x</p>
+<p>IBM WebSphere Application Server ND 9.0.5.x ND Image and JDK 8 on RHEL 9.x</p>
 <h2>Offer listing</h2>
 <h3>Name</h3>
-<p>IBM WebSphere Application Server ND 9.0.5.x Base Image and JDK 8 on RHEL 9.x</p>
+<p>IBM WebSphere Application Server ND 9.0.5.x ND Image and JDK 8 on RHEL 9.x</p>
 <h3>Search results summary</h3>
-<p>IBM WebSphere Application Server ND 9.0.5.x Base Image and JDK 8 on Red Hat Enterprise Linux 9.x</p>
+<p>IBM WebSphere Application Server ND 9.0.5.x ND Image and JDK 8 on Red Hat Enterprise Linux 9.x</p>
 <h3>Short description</h3>
-<p>IBM WebSphere Application Server ND 9.0.5.x Base Image and JDK 8 on Red Hat Enterprise Linux 9.x.</p>
+<p>IBM WebSphere Application Server ND 9.0.5.x ND Image and JDK 8 on Red Hat Enterprise Linux 9.x.</p>
 <h3>Description</h3>
-<p>This is an IBM WebSphere Application Server Network Deployment 9.0.5.x base image and JDK 8 with Red Hat Enterprise Linux 9.x.</p>
+<p>This is an IBM WebSphere Application Server Network Deployment 9.0.5.x ND image and JDK 8 with Red Hat Enterprise Linux 9.x.</p>
 <p>The VM instance created by this offer is suitable for customers that require very highly customized Azure deployments. 
 Users of this offer are expected to be familiar with WebSphere Application Server administration. The VM is installed with
 the specified GNU/Linux distribution, IBM JDK version, and WebSphere Application Server Network Deployment version. 
@@ -21,8 +21,9 @@ The relevant directories are listed here:</p>
 </ul>
 <p>There is no pre-created cluster. During VM creation, you are asked to provide a username and SSH key or credentials for the admin account.
 After logging in with this account, do sudo -i to get write access to the relevant directories.</p>
-<p>In addition to the VM base image, offers also include different solution templates to meet different scenarios on virtual machines, AKS and ARO such as 
-WebSphere Sever Single Instance/Cluster and WebSphere Liberty/Open Liberty on AKS/ARO. These offers are linked in the <i>Learn more</i> section at the bottom of the
+<p>In addition to the VM ihs image, other offers are available to meet different needs.  These includes solution templates for 
+    WebSphere Application Server Single Instance or Cluster in virtual machines and WebSphere Liberty/Open Liberty on AKS or ARO. 
+    These offers are linked in the <i>Learn more</i> section at the bottom of the
 <a href="https://ibm.biz/WebSphereOnAzureContactMe">IBM WebSphere Product Family on Azure</a> page.</p>
 <p>If you want to work closely on your migration scenarios with the engineering team developing these offers, just click the CONTACT ME button on the
 <a href="https://ibm.biz/WebSphereOnAzureContactMe">IBM WebSphere Product Family on Azure</a> page.
@@ -31,6 +32,8 @@ Program managers, architects and engineers will reach back out to you shortly an
 <ul>
 <li><a href="https://learn.microsoft.com/en-us/azure/developer/java/ee/websphere-family">WebSphere on Azure</a></li>
 <li><a href="https://ibm.biz/WebSphereOnAzureContactMe">IBM WebSphere Product Family on Azure</a></li>
+<li><a href="https://aka.ms/twas-IHS-portal">WebSphere IHS Image on Azure VM</a></li>
+<li><a href="https://aka.ms/twas-Base-portal">WebSphere Base Image on Azure VM</a></li>
 <li><a href="https://aka.ms/twas-single-portal">WebSphere Single Instance on Azure VM</a></li>
 <li><a href="https://aka.ms/twas-cluster-portal">WebSphere Cluster on Azure VMs</a></li>
 <li><a href="https://aka.ms/liberty-aro">WebSphere Liberty/Open Liberty on ARO</a></li>

--- a/twas-nd/src/main/resources/marketing-artifacts/partner-center.html
+++ b/twas-nd/src/main/resources/marketing-artifacts/partner-center.html
@@ -1,16 +1,16 @@
 <h1>Azure Virtual Machine Offer</h1>
 <h2>Offer setup</h2>
 <h3>Alias</h3>
-<p>IBM WebSphere Application Server ND 9.0.5.x ND Image and JDK 8 on RHEL 9.x</p>
+<p>IBM WebSphere Application Server ND 9.0.5.x Image and JDK 8 on RHEL 9.x</p>
 <h2>Offer listing</h2>
 <h3>Name</h3>
-<p>IBM WebSphere Application Server ND 9.0.5.x ND Image and JDK 8 on RHEL 9.x</p>
+<p>IBM WebSphere Application Server ND 9.0.5.x Image and JDK 8 on RHEL 9.x</p>
 <h3>Search results summary</h3>
-<p>IBM WebSphere Application Server ND 9.0.5.x ND Image and JDK 8 on Red Hat Enterprise Linux 9.x</p>
+<p>IBM WebSphere Application Server ND 9.0.5.x Image and JDK 8 on Red Hat Enterprise Linux 9.x</p>
 <h3>Short description</h3>
-<p>IBM WebSphere Application Server ND 9.0.5.x ND Image and JDK 8 on Red Hat Enterprise Linux 9.x.</p>
+<p>IBM WebSphere Application Server ND 9.0.5.x Image and JDK 8 on Red Hat Enterprise Linux 9.x.</p>
 <h3>Description</h3>
-<p>This is an IBM WebSphere Application Server Network Deployment 9.0.5.x ND image and JDK 8 with Red Hat Enterprise Linux 9.x.</p>
+<p>This is an IBM WebSphere Application Server Network Deployment 9.0.5.x Image and JDK 8 with Red Hat Enterprise Linux 9.x.</p>
 <p>The VM instance created by this offer is suitable for customers that require very highly customized Azure deployments. 
 Users of this offer are expected to be familiar with WebSphere Application Server administration. The VM is installed with
 the specified GNU/Linux distribution, IBM JDK version, and WebSphere Application Server Network Deployment version. 
@@ -21,7 +21,7 @@ The relevant directories are listed here:</p>
 </ul>
 <p>There is no pre-created cluster. During VM creation, you are asked to provide a username and SSH key or credentials for the admin account.
 After logging in with this account, do sudo -i to get write access to the relevant directories.</p>
-<p>In addition to the VM ihs image, other offers are available to meet different needs.  These includes solution templates for 
+<p>In addition to the VM ND image, other offers are available to meet different needs.  These includes solution templates for 
     WebSphere Application Server Single Instance or Cluster in virtual machines and WebSphere Liberty/Open Liberty on AKS or ARO. 
     These offers are linked in the <i>Learn more</i> section at the bottom of the
 <a href="https://ibm.biz/WebSphereOnAzureContactMe">IBM WebSphere Product Family on Azure</a> page.</p>

--- a/twas-nd/src/main/resources/marketing-artifacts/partner-center.html
+++ b/twas-nd/src/main/resources/marketing-artifacts/partner-center.html
@@ -32,8 +32,8 @@ Program managers, architects and engineers will reach back out to you shortly an
 <ul>
 <li><a href="https://learn.microsoft.com/en-us/azure/developer/java/ee/websphere-family">WebSphere on Azure</a></li>
 <li><a href="https://ibm.biz/WebSphereOnAzureContactMe">IBM WebSphere Product Family on Azure</a></li>
-<li><a href="https://ibm.biz/twas-IHS-portal">WebSphere IHS Image on Azure VM</a></li>
-<li><a href="https://ibm.biz/twas-Base-portal">WebSphere Base Image on Azure VM</a></li>
+<li><a href="https://ibm.biz/twas-ihs-portal">WebSphere IHS Image on Azure VM</a></li>
+<li><a href="https://ibm.biz/twas-base-portal">WebSphere Base Image on Azure VM</a></li>
 <li><a href="https://aka.ms/twas-single-portal">WebSphere Single Instance on Azure VM</a></li>
 <li><a href="https://aka.ms/twas-cluster-portal">WebSphere Cluster on Azure VMs</a></li>
 <li><a href="https://aka.ms/liberty-aro">WebSphere Liberty/Open Liberty on ARO</a></li>

--- a/twas-nd/src/main/resources/marketing-artifacts/partner-center.html
+++ b/twas-nd/src/main/resources/marketing-artifacts/partner-center.html
@@ -37,5 +37,5 @@ Program managers, architects and engineers will reach back out to you shortly an
 <li><a href="https://aka.ms/twas-single-portal">WebSphere Single Instance on Azure VM</a></li>
 <li><a href="https://aka.ms/twas-cluster-portal">WebSphere Cluster on Azure VMs</a></li>
 <li><a href="https://aka.ms/liberty-aro">WebSphere Liberty/Open Liberty on ARO</a></li>
-<li><a href="https://aka.ms/liberty-aks">WebSphere Liberty/Open Liberty on AKS</a></li>
+<li><a href="https://ibm.biz/liberty-aks">WebSphere Liberty/Open Liberty on AKS</a></li>
 </ul>

--- a/twas-nd/src/main/resources/marketing-artifacts/partner-center.html
+++ b/twas-nd/src/main/resources/marketing-artifacts/partner-center.html
@@ -32,8 +32,8 @@ Program managers, architects and engineers will reach back out to you shortly an
 <ul>
 <li><a href="https://learn.microsoft.com/en-us/azure/developer/java/ee/websphere-family">WebSphere on Azure</a></li>
 <li><a href="https://ibm.biz/WebSphereOnAzureContactMe">IBM WebSphere Product Family on Azure</a></li>
-<li><a href="https://aka.ms/twas-IHS-portal">WebSphere IHS Image on Azure VM</a></li>
-<li><a href="https://aka.ms/twas-Base-portal">WebSphere Base Image on Azure VM</a></li>
+<li><a href="https://ibm.biz/twas-IHS-portal">WebSphere IHS Image on Azure VM</a></li>
+<li><a href="https://ibm.biz/twas-Base-portal">WebSphere Base Image on Azure VM</a></li>
 <li><a href="https://aka.ms/twas-single-portal">WebSphere Single Instance on Azure VM</a></li>
 <li><a href="https://aka.ms/twas-cluster-portal">WebSphere Cluster on Azure VMs</a></li>
 <li><a href="https://aka.ms/liberty-aro">WebSphere Liberty/Open Liberty on ARO</a></li>


### PR DESCRIPTION
This PR has updates for partner-center.html files for the following VM image offerings.
Refer to the [slack messages](https://ibm-cloud.slack.com/archives/G010BB252NA/p1677206297444609) for comments.
1. Base
2. ND
3. IHS

I have used following links for VM images at the bottom of each partner-center.html. I am not sure how these links get created.
```
<li><a href="https://ibm.biz/twas-nd-portal">WebSphere ND Image on Azure VM</a></li>
<li><a href="https://ibm.biz/twas-base-portal">WebSphere Base Image on Azure VM</a></li>
<li><a href="https://ibm.biz/twas-ihs-portal">WebSphere IHS Image on Azure VM</a></li>
```

Also, I see the partner-center.html files referring to [IBM WebSphere Product Family on Azure](https://ibm.biz/WebSphereOnAzureContactMe) ; this link should also include VM image offerings.