### PR TITLE
Display welcome message with instructions after successful ssh login

### DIFF
--- a/ihs/pom.xml
+++ b/ihs/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.websphere-ihs.image</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/ihs/src/main/arm/mainTemplate.json
+++ b/ihs/src/main/arm/mainTemplate.json
@@ -286,7 +286,8 @@ sudo mkdir /datadrive && sudo mount /dev/${disk}1 /datadrive",
                     "fileUris": [
                         "[uri(variables('const_scriptLocation'), concat('install.sh', parameters('_artifactsLocationSasToken')))]",
                         "[uri(variables('const_scriptLocation'), concat('was-check.sh', parameters('_artifactsLocationSasToken')))]",
-                        "[uri(variables('const_scriptLocation'), concat('virtualimage.properties', parameters('_artifactsLocationSasToken')))]"
+                        "[uri(variables('const_scriptLocation'), concat('virtualimage.properties', parameters('_artifactsLocationSasToken')))]",
+                        "[uri(variables('const_scriptLocation'), concat('welcome.motd', parameters('_artifactsLocationSasToken')))]"
                     ],
                     "commandToExecute": "[concat('sh install.sh', variables('const_arguments'))]"
                 }

--- a/ihs/src/main/scripts/install.sh
+++ b/ihs/src/main/scripts/install.sh
@@ -36,6 +36,12 @@ done
 name=$(df -h | grep "/datadrive" | awk '{print $1;}' | grep -Po "(?<=\/dev\/).*")
 echo "UUID=$(blkid | grep -Po "(?<=\/dev\/${name}\: UUID=\")[^\"]*(?=\".*)")   /datadrive   xfs   defaults,nofail   1   2" >> /etc/fstab
 
+# Move welcome message to /etc/motd.d and set appropriate permissions and SELinux context
+mv welcome.motd /etc/motd.d
+chmod 644 /etc/motd.d/welcome.motd
+semanage fcontext -a -t etc_t -s system_u /etc/motd.d/welcome.motd
+restorecon -vF /etc/motd.d/welcome.motd
+
 # Move entitlement check and application patch script to /var/lib/cloud/scripts/per-instance
 mv was-check.sh /var/lib/cloud/scripts/per-instance
 

--- a/ihs/src/main/scripts/welcome.motd
+++ b/ihs/src/main/scripts/welcome.motd
@@ -1,0 +1,15 @@
+                                        
+========================================
+The VM is installed with the specified GNU/Linux distribution, IBM JDK version, and IBM HTTP Server for WebSphere Application Server version. 
+The relevant directories are as follows:
+* IHS_INSTALL_ROOT: /datadrive/IBM/WebSphere/IHS/V9
+* IHS_JAVA_HOME: ${IHS_INSTALL_ROOT}/java/8.0
+* PLUGINS_INSTALL_ROOT: /datadrive/IBM/WebSphere/Plugins/V9
+* PLUGINS_JAVA_HOME: ${PLUGINS_INSTALL_ROOT}/java/8.0
+* WCT_INSTALL_ROOT: /datadrive/IBM/WebSphere/Toolbox/V9
+* WCT_JAVA_HOME: ${WCT_INSTALL_ROOT}/java/8.0
+
+IBM HTTP Server for WebSphere Application Server is not pre-configured. 
+You need to do 'sudo -i' to get write access to the relevant directories for further configuration.
+========================================
+                                        

--- a/twas-base/pom.xml
+++ b/twas-base/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.websphere-base.image</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/twas-base/src/main/arm/mainTemplate.json
+++ b/twas-base/src/main/arm/mainTemplate.json
@@ -286,7 +286,8 @@ sudo mkdir /datadrive && sudo mount /dev/${disk}1 /datadrive",
                     "fileUris": [
                         "[uri(variables('const_scriptLocation'), concat('install.sh', parameters('_artifactsLocationSasToken')))]",
                         "[uri(variables('const_scriptLocation'), concat('was-check.sh', parameters('_artifactsLocationSasToken')))]",
-                        "[uri(variables('const_scriptLocation'), concat('virtualimage.properties', parameters('_artifactsLocationSasToken')))]"
+                        "[uri(variables('const_scriptLocation'), concat('virtualimage.properties', parameters('_artifactsLocationSasToken')))]",
+                        "[uri(variables('const_scriptLocation'), concat('welcome.motd', parameters('_artifactsLocationSasToken')))]"
                     ],
                     "commandToExecute": "[concat('sh install.sh', variables('const_arguments'))]"
                 }

--- a/twas-base/src/main/scripts/install.sh
+++ b/twas-base/src/main/scripts/install.sh
@@ -36,6 +36,12 @@ done
 name=$(df -h | grep "/datadrive" | awk '{print $1;}' | grep -Po "(?<=\/dev\/).*")
 echo "UUID=$(blkid | grep -Po "(?<=\/dev\/${name}\: UUID=\")[^\"]*(?=\".*)")   /datadrive   xfs   defaults,nofail   1   2" >> /etc/fstab
 
+# Move welcome message to /etc/motd.d and set appropriate permissions and SELinux context
+mv welcome.motd /etc/motd.d
+chmod 644 /etc/motd.d/welcome.motd
+semanage fcontext -a -t etc_t -s system_u /etc/motd.d/welcome.motd
+restorecon -vF /etc/motd.d/welcome.motd
+
 # Move tWAS entitlement check and application patch script to /var/lib/cloud/scripts/per-instance
 mv was-check.sh /var/lib/cloud/scripts/per-instance
 

--- a/twas-base/src/main/scripts/welcome.motd
+++ b/twas-base/src/main/scripts/welcome.motd
@@ -1,0 +1,11 @@
+                                        
+========================================
+The VM is installed with the specified GNU/Linux distribution, IBM JDK version, and WebSphere Application Server Base Deployment version.
+The relevant directories are as follows:
+* WAS_INSTALL_ROOT: /datadrive/IBM/WebSphere/Base/V9
+* JAVA_HOME: ${WAS_INSTALL_ROOT}/java/8.0
+
+The application server profile and server instance are not pre-created.
+You need to do 'sudo -i' to get write access to the relevant directories for further configuration.
+========================================
+                                        

--- a/twas-nd/pom.xml
+++ b/twas-nd/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.websphere-traditional.image</artifactId>
-    <version>1.0.6</version>
+    <version>1.0.7</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/twas-nd/src/main/arm/mainTemplate.json
+++ b/twas-nd/src/main/arm/mainTemplate.json
@@ -286,7 +286,8 @@ sudo mkdir /datadrive && sudo mount /dev/${disk}1 /datadrive",
                     "fileUris": [
                         "[uri(variables('const_scriptLocation'), concat('install.sh', parameters('_artifactsLocationSasToken')))]",
                         "[uri(variables('const_scriptLocation'), concat('was-check.sh', parameters('_artifactsLocationSasToken')))]",
-                        "[uri(variables('const_scriptLocation'), concat('virtualimage.properties', parameters('_artifactsLocationSasToken')))]"
+                        "[uri(variables('const_scriptLocation'), concat('virtualimage.properties', parameters('_artifactsLocationSasToken')))]",
+                        "[uri(variables('const_scriptLocation'), concat('welcome.motd', parameters('_artifactsLocationSasToken')))]"
                     ],
                     "commandToExecute": "[concat('sh install.sh', variables('const_arguments'))]"
                 }

--- a/twas-nd/src/main/scripts/install.sh
+++ b/twas-nd/src/main/scripts/install.sh
@@ -36,6 +36,12 @@ done
 name=$(df -h | grep "/datadrive" | awk '{print $1;}' | grep -Po "(?<=\/dev\/).*")
 echo "UUID=$(blkid | grep -Po "(?<=\/dev\/${name}\: UUID=\")[^\"]*(?=\".*)")   /datadrive   xfs   defaults,nofail   1   2" >> /etc/fstab
 
+# Move welcome message to /etc/motd.d and set appropriate permissions and SELinux context
+mv welcome.motd /etc/motd.d
+chmod 644 /etc/motd.d/welcome.motd
+semanage fcontext -a -t etc_t -s system_u /etc/motd.d/welcome.motd
+restorecon -vF /etc/motd.d/welcome.motd
+
 # Move tWAS entitlement check and application patch script to /var/lib/cloud/scripts/per-instance
 mv was-check.sh /var/lib/cloud/scripts/per-instance
 

--- a/twas-nd/src/main/scripts/welcome.motd
+++ b/twas-nd/src/main/scripts/welcome.motd
@@ -1,0 +1,11 @@
+                                        
+========================================
+The VM is installed with the specified GNU/Linux distribution, IBM JDK version, and WebSphere Application Server Network Deployment version. 
+The relevant directories are as follows:
+* WAS_INSTALL_ROOT: /datadrive/IBM/WebSphere/ND/V9
+* JAVA_HOME: ${WAS_INSTALL_ROOT}/java/8.0
+
+Clusters, profiles, and server instances are not pre-created.
+You need to do 'sudo -i' to get write access to the relevant directories for further configuration.
+========================================
+                                        


### PR DESCRIPTION
@git4rk made a good suggestion in the slack thread:
> We have to make sure instructions are clear to avoid any customer case. Can we display a message when customer logs into the VM?

This PR is to address the request by displaying a welcome message after a successful ssh login, including the necessary instructions about how to do further configuration after switching to root with `sudo -i`.

## Testing

Workflow for each pipeline ran successfully:
* [twas-nd CICD](https://github.com/majguo/azure.websphere-traditional.image/actions/runs/4489260794)
* [ihs CICD](https://github.com/majguo/azure.websphere-traditional.image/actions/runs/4489261816)
* [twas-base CICD](https://github.com/majguo/azure.websphere-traditional.image/actions/runs/4489262684)

See the sample welcome message in the red box from the screenshot below, which is captured from console output when I logged into the twas-base VM created by the vm image (not VM offer yet as it's in process of publishing, but should be enough for testing purpose):
![image](https://user-images.githubusercontent.com/10357495/226893164-2a9949f8-a0c4-40a2-b80c-5d9d7d25760e.png)

## Text review

@edburns @git4rk @gcharters @venunathb @m-reza-rahman The welcome messages are copied from the relative partner-center.html file, pls review:
* [twas-nd/src/main/scripts/welcome.motd](https://github.com/WASdev/azure.websphere-traditional.image/pull/71/files#diff-ddb00864a3e83531cc90a6732200729b561bc5b2d865bc09c97c587f5df8c898)
* [ihs/src/main/scripts/welcome.motd](https://github.com/WASdev/azure.websphere-traditional.image/pull/71/files#diff-742e5dffc8c128ad1c6fd79eeecfda24dc3414407dda66809ed41a0833903b88)
* [twas-base/src/main/scripts/welcome.motd](https://github.com/WASdev/azure.websphere-traditional.image/pull/71/files#diff-97eeabb370b06209a893864ad1c5b85068fb500c2e2ca21435c95f87ba130288)

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>