### PR TITLE
On branch edburns-msft-ibm-247-revert-use-of-automatic-publishing-02

### DIFF
--- a/.github/workflows/twas-baseBuild.yml
+++ b/.github/workflows/twas-baseBuild.yml
@@ -181,7 +181,6 @@ jobs:
             az network nsg delete --ids \
               $(az network nsg list -g ${{ env.testResourceGroup }} --query [0].id -o tsv)
       - name: Generate SAS url
-        id: sas_url
         run: |
           # Get a minus-24-hour date and a plus-30-day date for the SAS token
           minus24HoursUtc=$(date -u --date "$dte -24 hour" +%Y-%m-%dT%H:%MZ)
@@ -194,29 +193,13 @@ jobs:
           blobStorageEndpoint=$( az storage account show -n ${{ env.vhdStorageAccountName }} -g ${{ env.testResourceGroup }} -o json | jq -r '.primaryEndpoints.blob' )
           osDiskSasUrl=${blobStorageEndpoint}vhds/${{ env.vmName }}.vhd?$sasToken
           dataDiskSasUrl=${blobStorageEndpoint}vhds/${{ env.vmName }}datadisk1.vhd?$sasToken
-
+          
           echo "osDiskSasUrl: ${osDiskSasUrl}, dataDiskSasUrl: ${dataDiskSasUrl}" > sas-url-twasbase.txt
       - name: Upload SAS url
         uses: actions/upload-artifact@v3
         with:
           name: sasurl-twasbase
           path: sas-url-twasbase.txt
-      - name: Update offer sas url and version
-        uses: microsoft/microsoft-partner-center-github-action@v2
-        if: ${{ github.repository_owner == 'WASdev' }}
-        with:
-          offerName: ${{ env.offerName }}
-          planName: ${{ env.planName }}
-          clientId: ${{ env.clientId }}
-          secretValue: ${{ env.secretValue }}
-          tenantId: ${{ env.tenantId }}
-          offerType: ${{ env.offerType }}
-          imageVersionNumber: ${{ steps.setup-env-variables-based-on-dispatch-event.outputs.imageVersionNumber }}
-          imageType: ${{ env.imageType }}
-          operatingSystemFamily: ${{ env.operatingSystemFamily }}
-          operatingSystemType: ${{ env.operatingSystemType }}
-          osDiskSasUrl: ${{steps.sas_url.outputs.osDiskSasUrl}}
-          dataDiskSasUrl: ${{steps.sas_url.outputs.dataDiskSasUrl}}
   summary:
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
modified:   .github/workflows/twas-baseBuild.yml

@majguo  wrote:

> Meanwhile, the revert for twas-base in https://github.com/WASdev/azure.websphere-traditional.image/pull/75 hasn't covered everything needs to be reverted, so [twas-base CICD](https://github.com/WASdev/azure.websphere-traditional.image/actions/runs/4835898187) still failed. You need make further changes by referring to successful reverts for twas-nd or ihs, and re-run twas-base cicd.
> As a result, instead of fixing the revert of twas-base pipeline, we can also add back the automatic publish to the pipelines after re-publishing V2 release of the action. Pls make the call and take relative actions. (edited)

This commit completes the revert.  Thanks Jianguo.
