### PR TITLE
Integrate twas-single & twas-cluster integration test into image build pipeline

### DIFF
--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -37,6 +37,8 @@ env:
   location: eastus
   scriptLocation: https://raw.githubusercontent.com/${{ secrets.USER_NAME }}/azure.websphere-traditional.image/$GITHUB_REF_NAME/ihs/test/
   utilitiesLocation: https://raw.githubusercontent.com/${{ secrets.USER_NAME }}/azure.websphere-traditional.image/$GITHUB_REF_NAME/utilities/
+  accessToken: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+  twasClusterRepo: ${{ secrets.USER_NAME }}/azure.websphere-traditional.cluster
   offerId: "2023-03-27-ihs-base-image"
   planId: "2023-03-27-ihs-base-image"
   offerType: "vm_image_offer"
@@ -186,6 +188,54 @@ jobs:
             
             az group delete -n $rgName --yes --no-wait
           done
+
+          # Verify the image with twas-cluster integration-test pipeline
+          requestData={\"ref\":\"main\",\"inputs\":{\"databaseType\":\"none\",\"ndImageResourceId\":\"\",\"ihsImageResourceId\":\"${imageResourceId}\"}}
+          curl --verbose -L -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${accessToken}"\
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ env.twasClusterRepo }}/actions/workflows/integration-test.yaml/dispatches \
+            -d $(echo $requestData | jq -c)
+          # Wait for the workflow run being created
+          sleep 60
+          workflowRunId=$(curl -L \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${accessToken}"\
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ env.twasClusterRepo }}/actions/workflows/integration-test.yaml/runs \
+            | jq '.workflow_runs[0].id')
+          status=$(curl -L \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${accessToken}"\
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ env.twasClusterRepo }}/actions/runs/$workflowRunId \
+            | jq -r '.status')
+          while [[ $status != completed ]]
+          do
+              sleep 10
+              echo "Wait until the workflow run ${workflowRunId} completes..."
+              status=$(curl -L \
+                -H "Accept: application/vnd.github+json" \
+                -H "Authorization: Bearer ${accessToken}"\
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                https://api.github.com/repos/${{ env.twasClusterRepo }}/actions/runs/$workflowRunId \
+                | jq -r '.status')
+              echo "Workflow run ${workflowRunId} is ${status}"
+          done
+          jobs=$(curl -L \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${accessToken}"\
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ env.twasClusterRepo }}/actions/runs/$workflowRunId/jobs)
+          successIntegTestJobCnt=$(echo $jobs | jq 'select(.jobs != null) | .jobs | map(select(.name=="integration-test" and .conclusion=="success")) | length')
+          
+          if [[ $successIntegTestJobCnt != 1 ]]; then
+            echo "twas-cluster integration test workflow run ${workflowRunId} failed."
+            exit 1
+          else
+            echo "twas-cluster integration test workflow run ${workflowRunId} succeeded."
+          fi
       - name: Clean up all resources except for vhd storage account
         uses: azure/CLI@v1
         with:

--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -296,15 +296,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - name: Download SAS url
-        uses: actions/download-artifact@v3
-        with:
-          name: sasurl-ihs
-      - name: Download openscap scanning report before remidation
-        uses: actions/download-artifact@v3
-        with:
-          name: scan-report-before
-      - name: Download openscap scanning report after remidation
-        uses: actions/download-artifact@v3
-        with:
-          name: scan-report-after
+      - name: Output inputs from workflow_dispatch
+        run: echo "${{ toJSON(github.event.inputs) }}"
+      - name: Output client_payload from repository_dispatch
+        run: echo "${{ toJSON(github.event.client_payload) }}"

--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -11,14 +11,15 @@ on:
   # Allows you to run this workflow using GitHub APIs
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
   # REPO_NAME=WASdev/azure.websphere-traditional.image
-  # curl --verbose -XPOST -u "WASdev:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/actions/workflows/ihsBuild.yml/dispatches --data '{"ref": "main", "inputs": {"imageVersionNumber": "9.0.20230428"}}'
+  # curl --verbose -X POST -u "WASdev:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/actions/workflows/ihsBuild.yml/dispatches --data '{"ref": "main", "inputs": {"imageVersionNumber": "9.0.20230428"}}'
   repository_dispatch:
     types: [integration-test-ihs, integration-test-all]
   # sample request
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
   # REPO_NAME=WASdev/azure.websphere-traditional.image
-  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test-ihs"}'
-  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test-all"}'
+  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test-ihs", "client_payload": {"imageVersionNumber": "9.0.20230428"}}'
+  # The integration-test-all event is used to run all integration tests (twas-base, twas-nd & ihs) in the repository with the same image version number.
+  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test-all", "client_payload": {"imageVersionNumber": "9.0.20230428"}}'
 
 env:
   repoName: azure.websphere-traditional.image

--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -183,7 +183,7 @@ jobs:
                 imageResourceId=$imageResourceId vmAdminId=${{ env.vmAdminId }} vmAdminPwd=${{ env.vmAdminPassword }} \
                 scriptLocation=${{ env.scriptLocation }}
             
-            az group delete -n $rgName --yes
+            az group delete -n $rgName --yes --no-wait
           done
       - name: Clean up all resources except for vhd storage account
         uses: azure/CLI@v1

--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -170,7 +170,9 @@ jobs:
       - name: Verify the image
         run: |
           imageResourceId=$(az image show --name ${{ env.vmName }} --resource-group ${{ env.testResourceGroup }} --query id -o tsv)
-          
+          echo "ihsImageResourceId=${imageResourceId}" >> $GITHUB_ENV
+          echo "ndImageResourceId=" >> $GITHUB_ENV
+
           # Deploy VMs using different IBMids and verify installation
           vmGroups=( ${{ env.testResourceGroup }}-entitled ${{ env.testResourceGroup }}-unentitled ${{ env.testResourceGroup }}-evaluation )
           deploymentModes=( Entitled Unentitled Evaluation )
@@ -188,23 +190,40 @@ jobs:
             
             az group delete -n $rgName --yes --no-wait
           done
-
-          # Verify the image with twas-cluster integration-test pipeline
-          requestData={\"ref\":\"main\",\"inputs\":{\"databaseType\":\"none\",\"ndImageResourceId\":\"\",\"ihsImageResourceId\":\"${imageResourceId}\"}}
+      - name: Verify the image with twas-cluster integration-test pipeline
+        run: |
+          # Trigger the workflow run
+          requestData={\"ref\":\"main\",\"inputs\":{\"databaseType\":\"none\",\"ndImageResourceId\":\"${ndImageResourceId}\",\"ihsImageResourceId\":\"${ihsImageResourceId}\"}}
           curl --verbose -L -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${accessToken}"\
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${{ env.twasClusterRepo }}/actions/workflows/integration-test.yaml/dispatches \
             -d $(echo $requestData | jq -c)
-          # Wait for the workflow run being created
-          sleep 60
-          workflowRunId=$(curl -L \
+          
+          # Wait until the workflow run starts
+          idAndStatus=$(curl -L \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${accessToken}"\
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${{ env.twasClusterRepo }}/actions/workflows/integration-test.yaml/runs \
-            | jq '.workflow_runs[0].id')
+            | jq -r '.workflow_runs[0] | {id, status}')
+          status=$(echo $idAndStatus | jq -r '.status')
+          while [[ $status != queued ]]
+          do
+            echo "Wait until the workflow run starts..."
+            idAndStatus=$(curl -L \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${accessToken}"\
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              https://api.github.com/repos/${{ env.twasClusterRepo }}/actions/workflows/integration-test.yaml/runs \
+              | jq -r '.workflow_runs[0] | {id, status}')
+            status=$(echo $idAndStatus | jq -r '.status')
+            echo "The latest workflow run is ${idAndStatus}"
+          done
+          workflowRunId=$(echo $idAndStatus | jq '.id')
+
+          # Wait until the workflow run completes
           status=$(curl -L \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${accessToken}"\
@@ -213,23 +232,24 @@ jobs:
             | jq -r '.status')
           while [[ $status != completed ]]
           do
-              sleep 10
-              echo "Wait until the workflow run ${workflowRunId} completes..."
-              status=$(curl -L \
-                -H "Accept: application/vnd.github+json" \
-                -H "Authorization: Bearer ${accessToken}"\
-                -H "X-GitHub-Api-Version: 2022-11-28" \
-                https://api.github.com/repos/${{ env.twasClusterRepo }}/actions/runs/$workflowRunId \
-                | jq -r '.status')
-              echo "Workflow run ${workflowRunId} is ${status}"
+            sleep 10
+            echo "Wait until the workflow run ${workflowRunId} completes..."
+            status=$(curl -L \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${accessToken}"\
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              https://api.github.com/repos/${{ env.twasClusterRepo }}/actions/runs/$workflowRunId \
+              | jq -r '.status')
+            echo "Workflow run ${workflowRunId} is ${status}"
           done
+          
+          # Verify the workflow run result
           jobs=$(curl -L \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${accessToken}"\
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${{ env.twasClusterRepo }}/actions/runs/$workflowRunId/jobs)
           successIntegTestJobCnt=$(echo $jobs | jq 'select(.jobs != null) | .jobs | map(select(.name=="integration-test" and .conclusion=="success")) | length')
-          
           if [[ $successIntegTestJobCnt != 1 ]]; then
             echo "twas-cluster integration test workflow run ${workflowRunId} failed."
             exit 1

--- a/.github/workflows/setup-credentials.sh
+++ b/.github/workflows/setup-credentials.sh
@@ -39,6 +39,14 @@ ENTITLED_IBM_USER_PWD=
 UNENTITLED_IBM_USER_ID=
 # Password for unentitled IBMid
 UNENTITLED_IBM_USER_PWD=
+# Personal access token for the GitHub account
+PERSONAL_ACCESS_TOKEN=
+# Client ID for an Azure AD application registered in the Partner Center
+CLIENT_ID=
+# Secret value of the Azure AD application registered in the Partner Center
+SECRET_VALUE=
+# Tenant ID of the Azure AD application registered in the Partner Center
+TENANT_ID=
 
 # End set environment variables
 ################################################
@@ -121,6 +129,26 @@ if [ "$UNENTITLED_IBM_USER_PWD" == '' ] ; then
     read -r -p "Enter password for unentitled IBMid: " UNENTITLED_IBM_USER_PWD
 fi
 
+# get PERSONAL_ACCESS_TOKEN if not set at the beginning of this file
+if [ "$PERSONAL_ACCESS_TOKEN" == '' ] ; then
+    read -r -p "Enter personal access token for the GitHub account: " PERSONAL_ACCESS_TOKEN
+fi
+
+# get CLIENT_ID if not set at the beginning of this file
+if [ "$CLIENT_ID" == '' ] ; then
+    read -r -p "Enter client ID for an Azure AD application registered in the Partner Center: " CLIENT_ID
+fi
+
+# get SECRET_VALUE if not set at the beginning of this file
+if [ "$SECRET_VALUE" == '' ] ; then
+    read -r -p "Enter secret value for the Azure AD application registered in the Partner Center: " SECRET_VALUE
+fi
+
+# get TENANT_ID if not set at the beginning of this file
+if [ "$TENANT_ID" == '' ] ; then
+    read -r -p "Enter tenant ID for the Azure AD application registered in the Partner Center: " TENANT_ID
+fi
+
 SERVICE_PRINCIPAL_NAME=${DISAMBIG_PREFIX}sp
 
 # Check AZ CLI status
@@ -176,6 +204,10 @@ if $USE_GITHUB_CLI; then
     gh ${GH_FLAGS} secret set ENTITLED_IBM_USER_PWD -b"${ENTITLED_IBM_USER_PWD}"
     gh ${GH_FLAGS} secret set UNENTITLED_IBM_USER_ID -b"${UNENTITLED_IBM_USER_ID}"
     gh ${GH_FLAGS} secret set UNENTITLED_IBM_USER_PWD -b"${UNENTITLED_IBM_USER_PWD}"
+    gh ${GH_FLAGS} secret set PERSONAL_ACCESS_TOKEN -b"${PERSONAL_ACCESS_TOKEN}"
+    gh ${GH_FLAGS} secret set CLIENT_ID -b"${CLIENT_ID}"
+    gh ${GH_FLAGS} secret set SECRET_VALUE -b"${SECRET_VALUE}"
+    gh ${GH_FLAGS} secret set TENANT_ID -b"${TENANT_ID}"
     msg "${GREEN}Secrets configured"
   } || {
     USE_GITHUB_CLI=false
@@ -203,5 +235,13 @@ if [ $USE_GITHUB_CLI == false ]; then
   msg "${GREEN}${UNENTITLED_IBM_USER_ID}"
   msg "${YELLOW}\"UNENTITLED_IBM_USER_PWD\""
   msg "${GREEN}${UNENTITLED_IBM_USER_PWD}"
+  msg "${YELLOW}\"PERSONAL_ACCESS_TOKEN\""
+  msg "${GREEN}${PERSONAL_ACCESS_TOKEN}"
+  msg "${YELLOW}\"CLIENT_ID\""
+  msg "${GREEN}${CLIENT_ID}"
+  msg "${YELLOW}\"SECRET_VALUE\""
+  msg "${GREEN}${SECRET_VALUE}"
+  msg "${YELLOW}\"TENANT_ID\""
+  msg "${GREEN}${TENANT_ID}"
   msg "${NOFORMAT}========================================================================"
 fi

--- a/.github/workflows/tear-down-credentials.sh
+++ b/.github/workflows/tear-down-credentials.sh
@@ -80,6 +80,10 @@ if $USE_GITHUB_CLI; then
     gh ${GH_FLAGS} secret remove ENTITLED_IBM_USER_PWD
     gh ${GH_FLAGS} secret remove UNENTITLED_IBM_USER_ID
     gh ${GH_FLAGS} secret remove UNENTITLED_IBM_USER_PWD
+    gh ${GH_FLAGS} secret remove PERSONAL_ACCESS_TOKEN
+    gh ${GH_FLAGS} secret remove CLIENT_ID
+    gh ${GH_FLAGS} secret remove SECRET_VALUE
+    gh ${GH_FLAGS} secret remove TENANT_ID
     msg "${GREEN}Secrets removed"
   } || {
     USE_GITHUB_CLI=false
@@ -99,5 +103,9 @@ if [ $USE_GITHUB_CLI == false ]; then
   msg "${YELLOW}\"ENTITLED_IBM_USER_PWD\""
   msg "${YELLOW}\"UNENTITLED_IBM_USER_ID\""
   msg "${YELLOW}\"UNENTITLED_IBM_USER_PWD\""
+  msg "${YELLOW}\"PERSONAL_ACCESS_TOKEN\""
+  msg "${YELLOW}\"CLIENT_ID\""
+  msg "${YELLOW}\"SECRET_VALUE\""
+  msg "${YELLOW}\"TENANT_ID\""
   msg "${NOFORMAT}========================================================================"
 fi

--- a/.github/workflows/twas-baseBuild.yml
+++ b/.github/workflows/twas-baseBuild.yml
@@ -300,15 +300,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - name: Download SAS url
-        uses: actions/download-artifact@v3
-        with:
-          name: sasurl-twasbase
-      - name: Download openscap scanning report before remidation
-        uses: actions/download-artifact@v3
-        with:
-          name: scan-report-before
-      - name: Download openscap scanning report after remidation
-        uses: actions/download-artifact@v3
-        with:
-          name: scan-report-after
+      - name: Output inputs from workflow_dispatch
+        run: echo "${{ toJSON(github.event.inputs) }}"
+      - name: Output client_payload from repository_dispatch
+        run: echo "${{ toJSON(github.event.client_payload) }}"

--- a/.github/workflows/twas-baseBuild.yml
+++ b/.github/workflows/twas-baseBuild.yml
@@ -170,7 +170,8 @@ jobs:
       - name: Verify the image
         run: |
           imageResourceId=$(az image show --name ${{ env.vmName }} --resource-group ${{ env.testResourceGroup }} --query id -o tsv)
-          
+          echo "imageResourceId=${imageResourceId}" >> $GITHUB_ENV
+
           # Deploy VMs using different IBMids and verify installation
           vmGroups=( ${{ env.testResourceGroup }}-entitled ${{ env.testResourceGroup }}-unentitled ${{ env.testResourceGroup }}-evaluation )
           deploymentModes=( Entitled Unentitled Evaluation )
@@ -188,8 +189,9 @@ jobs:
             
             az group delete -n $rgName --yes --no-wait
           done
-
-          # Verify the image with twas-single integration-test pipeline
+      - name: Verify the image with twas-single integration-test pipeline
+        run: |
+          # Trigger the workflow run
           requestData={\"ref\":\"main\",\"inputs\":{\"databaseType\":\"none\",\"imageResourceId\":\"${imageResourceId}\"}}
           curl --verbose -L -X POST \
             -H "Accept: application/vnd.github+json" \
@@ -197,43 +199,56 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${{ env.twasSingleRepo }}/actions/workflows/integration-test.yaml/dispatches \
             -d $(echo $requestData | jq -c)
-          # Wait for the workflow run being created
-          sleep 60
-
-          workflowRunId=$(curl -L \
+          
+          # Wait until the workflow run starts
+          idAndStatus=$(curl -L \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${accessToken}"\
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${{ env.twasSingleRepo }}/actions/workflows/integration-test.yaml/runs \
-            | jq '.workflow_runs[0].id')
+            | jq -r '.workflow_runs[0] | {id, status}')
+          status=$(echo $idAndStatus | jq -r '.status')
+          while [[ $status != queued ]]
+          do
+            echo "Wait until the workflow run starts..."
+            idAndStatus=$(curl -L \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${accessToken}"\
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              https://api.github.com/repos/${{ env.twasSingleRepo }}/actions/workflows/integration-test.yaml/runs \
+              | jq -r '.workflow_runs[0] | {id, status}')
+            status=$(echo $idAndStatus | jq -r '.status')
+            echo "The latest workflow run is ${idAndStatus}"
+          done
+          workflowRunId=$(echo $idAndStatus | jq '.id')
 
+          # Wait until the workflow run completes
           status=$(curl -L \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${accessToken}"\
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${{ env.twasSingleRepo }}/actions/runs/$workflowRunId \
             | jq -r '.status')
-
           while [[ $status != completed ]]
           do
-              sleep 10
-              echo "Wait until the workflow run ${workflowRunId} completes..."
-              status=$(curl -L \
-                -H "Accept: application/vnd.github+json" \
-                -H "Authorization: Bearer ${accessToken}"\
-                -H "X-GitHub-Api-Version: 2022-11-28" \
-                https://api.github.com/repos/${{ env.twasSingleRepo }}/actions/runs/$workflowRunId \
-                | jq -r '.status')
-              echo "Workflow run ${workflowRunId} is ${status}"
+            sleep 10
+            echo "Wait until the workflow run ${workflowRunId} completes..."
+            status=$(curl -L \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${accessToken}"\
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              https://api.github.com/repos/${{ env.twasSingleRepo }}/actions/runs/$workflowRunId \
+              | jq -r '.status')
+            echo "Workflow run ${workflowRunId} is ${status}"
           done
-
+          
+          # Verify the workflow run result
           jobs=$(curl -L \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${accessToken}"\
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${{ env.twasSingleRepo }}/actions/runs/$workflowRunId/jobs)
           successIntegTestJobCnt=$(echo $jobs | jq 'select(.jobs != null) | .jobs | map(select(.name=="integration-test" and .conclusion=="success")) | length')
-          
           if [[ $successIntegTestJobCnt != 1 ]]; then
             echo "twas-single integration test workflow run ${workflowRunId} failed."
             exit 1

--- a/.github/workflows/twas-baseBuild.yml
+++ b/.github/workflows/twas-baseBuild.yml
@@ -183,7 +183,7 @@ jobs:
                 imageResourceId=$imageResourceId vmAdminId=${{ env.vmAdminId }} vmAdminPwd=${{ env.vmAdminPassword }} \
                 scriptLocation=${{ env.scriptLocation }}
             
-            az group delete -n $rgName --yes
+            az group delete -n $rgName --yes --no-wait
           done
       - name: Clean up all resources except for vhd storage account
         uses: azure/CLI@v1

--- a/.github/workflows/twas-baseBuild.yml
+++ b/.github/workflows/twas-baseBuild.yml
@@ -37,6 +37,8 @@ env:
   location: eastus
   scriptLocation: https://raw.githubusercontent.com/${{ secrets.USER_NAME }}/azure.websphere-traditional.image/$GITHUB_REF_NAME/twas-base/test/
   utilitiesLocation: https://raw.githubusercontent.com/${{ secrets.USER_NAME }}/azure.websphere-traditional.image/$GITHUB_REF_NAME/utilities/
+  accessToken: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+  twasSingleRepo: ${{ secrets.USER_NAME }}/azure.websphere-traditional.singleserver
   offerId: "2023-03-27-twas-single-server-base-image"
   planId: "2023-03-27-twas-single-server-base-image"
   offerType: "vm_image_offer"
@@ -186,6 +188,58 @@ jobs:
             
             az group delete -n $rgName --yes --no-wait
           done
+
+          # Verify the image with twas-single integration-test pipeline
+          requestData={\"ref\":\"main\",\"inputs\":{\"databaseType\":\"none\",\"imageResourceId\":\"${imageResourceId}\"}}
+          curl --verbose -L -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${accessToken}"\
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ env.twasSingleRepo }}/actions/workflows/integration-test.yaml/dispatches \
+            -d $(echo $requestData | jq -c)
+          # Wait for the workflow run being created
+          sleep 60
+
+          workflowRunId=$(curl -L \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${accessToken}"\
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ env.twasSingleRepo }}/actions/workflows/integration-test.yaml/runs \
+            | jq '.workflow_runs[0].id')
+
+          status=$(curl -L \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${accessToken}"\
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ env.twasSingleRepo }}/actions/runs/$workflowRunId \
+            | jq -r '.status')
+
+          while [[ $status != completed ]]
+          do
+              sleep 10
+              echo "Wait until the workflow run ${workflowRunId} completes..."
+              status=$(curl -L \
+                -H "Accept: application/vnd.github+json" \
+                -H "Authorization: Bearer ${accessToken}"\
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                https://api.github.com/repos/${{ env.twasSingleRepo }}/actions/runs/$workflowRunId \
+                | jq -r '.status')
+              echo "Workflow run ${workflowRunId} is ${status}"
+          done
+
+          jobs=$(curl -L \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${accessToken}"\
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ env.twasSingleRepo }}/actions/runs/$workflowRunId/jobs)
+          successIntegTestJobCnt=$(echo $jobs | jq 'select(.jobs != null) | .jobs | map(select(.name=="integration-test" and .conclusion=="success")) | length')
+          
+          if [[ $successIntegTestJobCnt != 1 ]]; then
+            echo "twas-single integration test workflow run ${workflowRunId} failed."
+            exit 1
+          else
+            echo "twas-single integration test workflow run ${workflowRunId} succeeded."
+          fi
       - name: Clean up all resources except for vhd storage account
         uses: azure/CLI@v1
         with:

--- a/.github/workflows/twas-baseBuild.yml
+++ b/.github/workflows/twas-baseBuild.yml
@@ -11,14 +11,15 @@ on:
   # Allows you to run this workflow using GitHub APIs
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
   # REPO_NAME=WASdev/azure.websphere-traditional.image
-  # curl --verbose -XPOST -u "WASdev:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/actions/workflows/twas-baseBuild.yml/dispatches --data '{"ref": "main", "inputs": {"imageVersionNumber": "9.0.20230428"}}'  
+  # curl --verbose -X POST -u "WASdev:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/actions/workflows/twas-baseBuild.yml/dispatches --data '{"ref": "main", "inputs": {"imageVersionNumber": "9.0.20230428"}}'
   repository_dispatch:
     types: [integration-test-twasbase, integration-test-all]
   # sample request
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
   # REPO_NAME=WASdev/azure.websphere-traditional.image
-  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test-twasbase"}'
-  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test-all"}'
+  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test-twasbase", "client_payload": {"imageVersionNumber": "9.0.20230428"}}'
+  # The integration-test-all event is used to run all integration tests (twas-base, twas-nd & ihs) in the repository with the same image version number.
+  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test-all", "client_payload": {"imageVersionNumber": "9.0.20230428"}}'
 
 env:
   repoName: azure.websphere-traditional.image

--- a/.github/workflows/twas-ndBuild.yml
+++ b/.github/workflows/twas-ndBuild.yml
@@ -11,14 +11,15 @@ on:
   # Allows you to run this workflow using GitHub APIs
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
   # REPO_NAME=WASdev/azure.websphere-traditional.image
-  # curl --verbose -XPOST -u "WASdev:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/actions/workflows/twas-ndBuild.yml/dispatches --data '{"ref": "main", "inputs": {"imageVersionNumber": "9.0.20230428"}}'  
+  # curl --verbose -X POST -u "WASdev:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/actions/workflows/twas-ndBuild.yml/dispatches --data '{"ref": "main", "inputs": {"imageVersionNumber": "9.0.20230428"}}'
   repository_dispatch:
     types: [integration-test-twasnd, integration-test-all]
   # sample request
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
   # REPO_NAME=WASdev/azure.websphere-traditional.image
-  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test-twasnd"}'
-  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test-all"}'
+  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test-twasnd", "client_payload": {"imageVersionNumber": "9.0.20230428"}}'
+  # The integration-test-all event is used to run all integration tests (twas-base, twas-nd & ihs) in the repository with the same image version number.
+  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test-all", "client_payload": {"imageVersionNumber": "9.0.20230428"}}'
 
 env:
   repoName: azure.websphere-traditional.image

--- a/.github/workflows/twas-ndBuild.yml
+++ b/.github/workflows/twas-ndBuild.yml
@@ -37,6 +37,8 @@ env:
   location: eastus
   scriptLocation: https://raw.githubusercontent.com/${{ secrets.USER_NAME }}/azure.websphere-traditional.image/$GITHUB_REF_NAME/twas-nd/test/
   utilitiesLocation: https://raw.githubusercontent.com/${{ secrets.USER_NAME }}/azure.websphere-traditional.image/$GITHUB_REF_NAME/utilities/
+  accessToken: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+  twasClusterRepo: ${{ secrets.USER_NAME }}/azure.websphere-traditional.cluster
   offerId: "2023-03-27-twas-cluster-base-image"
   planId: "2023-03-27-twas-cluster-base-image"
   offerType: "vm_image_offer"
@@ -186,6 +188,54 @@ jobs:
             
             az group delete -n $rgName --yes --no-wait
           done
+
+          # Verify the image with twas-cluster integration-test pipeline
+          requestData={\"ref\":\"main\",\"inputs\":{\"databaseType\":\"none\",\"ndImageResourceId\":\"${imageResourceId}\",\"ihsImageResourceId\":\"\"}}
+          curl --verbose -L -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${accessToken}"\
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ env.twasClusterRepo }}/actions/workflows/integration-test.yaml/dispatches \
+            -d $(echo $requestData | jq -c)
+          # Wait for the workflow run being created
+          sleep 60
+          workflowRunId=$(curl -L \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${accessToken}"\
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ env.twasClusterRepo }}/actions/workflows/integration-test.yaml/runs \
+            | jq '.workflow_runs[0].id')
+          status=$(curl -L \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${accessToken}"\
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ env.twasClusterRepo }}/actions/runs/$workflowRunId \
+            | jq -r '.status')
+          while [[ $status != completed ]]
+          do
+              sleep 10
+              echo "Wait until the workflow run ${workflowRunId} completes..."
+              status=$(curl -L \
+                -H "Accept: application/vnd.github+json" \
+                -H "Authorization: Bearer ${accessToken}"\
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                https://api.github.com/repos/${{ env.twasClusterRepo }}/actions/runs/$workflowRunId \
+                | jq -r '.status')
+              echo "Workflow run ${workflowRunId} is ${status}"
+          done
+          jobs=$(curl -L \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${accessToken}"\
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ env.twasClusterRepo }}/actions/runs/$workflowRunId/jobs)
+          successIntegTestJobCnt=$(echo $jobs | jq 'select(.jobs != null) | .jobs | map(select(.name=="integration-test" and .conclusion=="success")) | length')
+          
+          if [[ $successIntegTestJobCnt != 1 ]]; then
+            echo "twas-cluster integration test workflow run ${workflowRunId} failed."
+            exit 1
+          else
+            echo "twas-cluster integration test workflow run ${workflowRunId} succeeded."
+          fi
       - name: Clean up all resources except for vhd storage account
         uses: azure/CLI@v1
         with:

--- a/.github/workflows/twas-ndBuild.yml
+++ b/.github/workflows/twas-ndBuild.yml
@@ -183,7 +183,7 @@ jobs:
                 imageResourceId=$imageResourceId vmAdminId=${{ env.vmAdminId }} vmAdminPwd=${{ env.vmAdminPassword }} \
                 scriptLocation=${{ env.scriptLocation }}
             
-            az group delete -n $rgName --yes
+            az group delete -n $rgName --yes --no-wait
           done
       - name: Clean up all resources except for vhd storage account
         uses: azure/CLI@v1

--- a/.github/workflows/twas-ndBuild.yml
+++ b/.github/workflows/twas-ndBuild.yml
@@ -296,15 +296,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - name: Download SAS url
-        uses: actions/download-artifact@v3
-        with:
-          name: sasurl-twasnd
-      - name: Download openscap scanning report before remidation
-        uses: actions/download-artifact@v3
-        with:
-          name: scan-report-before
-      - name: Download openscap scanning report after remidation
-        uses: actions/download-artifact@v3
-        with:
-          name: scan-report-after
+      - name: Output inputs from workflow_dispatch
+        run: echo "${{ toJSON(github.event.inputs) }}"
+      - name: Output client_payload from repository_dispatch
+        run: echo "${{ toJSON(github.event.client_payload) }}"

--- a/.github/workflows/twas-ndBuild.yml
+++ b/.github/workflows/twas-ndBuild.yml
@@ -170,6 +170,8 @@ jobs:
       - name: Verify the image
         run: |
           imageResourceId=$(az image show --name ${{ env.vmName }} --resource-group ${{ env.testResourceGroup }} --query id -o tsv)
+          echo "ndImageResourceId=${imageResourceId}" >> $GITHUB_ENV
+          echo "ihsImageResourceId=" >> $GITHUB_ENV
           
           # Deploy VMs using different IBMids and verify installation
           vmGroups=( ${{ env.testResourceGroup }}-entitled ${{ env.testResourceGroup }}-unentitled ${{ env.testResourceGroup }}-evaluation )
@@ -188,23 +190,40 @@ jobs:
             
             az group delete -n $rgName --yes --no-wait
           done
-
-          # Verify the image with twas-cluster integration-test pipeline
-          requestData={\"ref\":\"main\",\"inputs\":{\"databaseType\":\"none\",\"ndImageResourceId\":\"${imageResourceId}\",\"ihsImageResourceId\":\"\"}}
+      - name: Verify the image with twas-cluster integration-test pipeline
+        run: |
+          # Trigger the workflow run
+          requestData={\"ref\":\"main\",\"inputs\":{\"databaseType\":\"none\",\"ndImageResourceId\":\"${ndImageResourceId}\",\"ihsImageResourceId\":\"${ihsImageResourceId}\"}}
           curl --verbose -L -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${accessToken}"\
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${{ env.twasClusterRepo }}/actions/workflows/integration-test.yaml/dispatches \
             -d $(echo $requestData | jq -c)
-          # Wait for the workflow run being created
-          sleep 60
-          workflowRunId=$(curl -L \
+          
+          # Wait until the workflow run starts
+          idAndStatus=$(curl -L \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${accessToken}"\
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${{ env.twasClusterRepo }}/actions/workflows/integration-test.yaml/runs \
-            | jq '.workflow_runs[0].id')
+            | jq -r '.workflow_runs[0] | {id, status}')
+          status=$(echo $idAndStatus | jq -r '.status')
+          while [[ $status != queued ]]
+          do
+            echo "Wait until the workflow run starts..."
+            idAndStatus=$(curl -L \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${accessToken}"\
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              https://api.github.com/repos/${{ env.twasClusterRepo }}/actions/workflows/integration-test.yaml/runs \
+              | jq -r '.workflow_runs[0] | {id, status}')
+            status=$(echo $idAndStatus | jq -r '.status')
+            echo "The latest workflow run is ${idAndStatus}"
+          done
+          workflowRunId=$(echo $idAndStatus | jq '.id')
+
+          # Wait until the workflow run completes
           status=$(curl -L \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${accessToken}"\
@@ -213,23 +232,24 @@ jobs:
             | jq -r '.status')
           while [[ $status != completed ]]
           do
-              sleep 10
-              echo "Wait until the workflow run ${workflowRunId} completes..."
-              status=$(curl -L \
-                -H "Accept: application/vnd.github+json" \
-                -H "Authorization: Bearer ${accessToken}"\
-                -H "X-GitHub-Api-Version: 2022-11-28" \
-                https://api.github.com/repos/${{ env.twasClusterRepo }}/actions/runs/$workflowRunId \
-                | jq -r '.status')
-              echo "Workflow run ${workflowRunId} is ${status}"
+            sleep 10
+            echo "Wait until the workflow run ${workflowRunId} completes..."
+            status=$(curl -L \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${accessToken}"\
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              https://api.github.com/repos/${{ env.twasClusterRepo }}/actions/runs/$workflowRunId \
+              | jq -r '.status')
+            echo "Workflow run ${workflowRunId} is ${status}"
           done
+          
+          # Verify the workflow run result
           jobs=$(curl -L \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${accessToken}"\
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${{ env.twasClusterRepo }}/actions/runs/$workflowRunId/jobs)
           successIntegTestJobCnt=$(echo $jobs | jq 'select(.jobs != null) | .jobs | map(select(.name=="integration-test" and .conclusion=="success")) | length')
-          
           if [[ $successIntegTestJobCnt != 1 ]]; then
             echo "twas-cluster integration test workflow run ${workflowRunId} failed."
             exit 1


### PR DESCRIPTION
The PR is to integrate twas-single & twas-cluster integration test into image build pipeline, so the private VM image can be tested by deploying it, configuring WAS, installing a sample application and accessing admin console + application before publishing to partner center.

## Testing

The following image build workflow runs successfully completed which integrate twas-single & twas-cluster integration test:
* [twas-base CICD](https://github.com/majguo/azure.websphere-traditional.image/actions/runs/5066959565)
* [twas-nd CICD](https://github.com/majguo/azure.websphere-traditional.image/actions/runs/5066960723)
* [ihs CICD](https://github.com/majguo/azure.websphere-traditional.image/actions/runs/5066958455)

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>