### PR TITLE
Fix recent pipeline failure 

### DIFF
--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -126,6 +126,13 @@ jobs:
               --name ${{ env.vmName }} -d \
               --query publicIps -o tsv)
             echo "publicIP=${publicIP}" >> $GITHUB_ENV
+      - name: Output installation log
+        run: |
+          sudo apt-get install -y sshpass
+          timeout 1m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${publicIP} 22
+          echo "Output stdout:"
+          result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${publicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S cat /var/lib/waagent/custom-script/download/0/stdout')
+          echo "$result"
       - name: Update the packages
         run: |
           sudo apt-get install -y sshpass
@@ -139,13 +146,10 @@ jobs:
             --publisher Microsoft.Azure.Extensions --version 2.0 \
             --settings "{\"fileUris\": [\"${{ env.utilitiesLocation }}oscap.sh\"]}" \
             --protected-settings "{\"commandToExecute\":\"bash oscap.sh ${{ env.vmAdminId }}\"}"
-      - name: Output installation log and copy openscap scanning reports
+      - name: Copy openscap scanning reports
         run: |
           sudo apt-get install -y sshpass
           timeout 1m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${publicIP} 22
-          echo "Output stdout:"
-          result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${publicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S cat /var/lib/waagent/custom-script/download/0/stdout')
-          echo "$result"
           sshpass -p ${vmAdminPassword} scp ${vmAdminId}@${publicIP}:/home/${vmAdminId}/scan_report_* .
       - name: Upload openscap scanning report before remidation
         uses: actions/upload-artifact@v3

--- a/.github/workflows/twas-baseBuild.yml
+++ b/.github/workflows/twas-baseBuild.yml
@@ -126,6 +126,13 @@ jobs:
               --name ${{ env.vmName }} -d \
               --query publicIps -o tsv)
             echo "publicIP=${publicIP}" >> $GITHUB_ENV
+      - name: Output installation log
+        run: |
+          sudo apt-get install -y sshpass
+          timeout 1m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${publicIP} 22
+          echo "Output stdout:"
+          result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${publicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S cat /var/lib/waagent/custom-script/download/0/stdout')
+          echo "$result"
       - name: Update the packages
         run: |
           sudo apt-get install -y sshpass
@@ -139,13 +146,10 @@ jobs:
             --publisher Microsoft.Azure.Extensions --version 2.0 \
             --settings "{\"fileUris\": [\"${{ env.utilitiesLocation }}oscap.sh\"]}" \
             --protected-settings "{\"commandToExecute\":\"bash oscap.sh ${{ env.vmAdminId }}\"}"
-      - name: Output installation log and copy openscap scanning reports
+      - name: Copy openscap scanning reports
         run: |
           sudo apt-get install -y sshpass
           timeout 1m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${publicIP} 22
-          echo "Output stdout:"
-          result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${publicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S cat /var/lib/waagent/custom-script/download/0/stdout')
-          echo "$result"
           sshpass -p ${vmAdminPassword} scp ${vmAdminId}@${publicIP}:/home/${vmAdminId}/scan_report_* .
       - name: Upload openscap scanning report before remidation
         uses: actions/upload-artifact@v3

--- a/.github/workflows/twas-ndBuild.yml
+++ b/.github/workflows/twas-ndBuild.yml
@@ -126,6 +126,13 @@ jobs:
               --name ${{ env.vmName }} -d \
               --query publicIps -o tsv)
             echo "publicIP=${publicIP}" >> $GITHUB_ENV
+      - name: Output installation log
+        run: |
+          sudo apt-get install -y sshpass
+          timeout 1m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${publicIP} 22
+          echo "Output stdout:"
+          result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${publicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S cat /var/lib/waagent/custom-script/download/0/stdout')
+          echo "$result"
       - name: Update the packages
         run: |
           sudo apt-get install -y sshpass
@@ -139,13 +146,10 @@ jobs:
             --publisher Microsoft.Azure.Extensions --version 2.0 \
             --settings "{\"fileUris\": [\"${{ env.utilitiesLocation }}oscap.sh\"]}" \
             --protected-settings "{\"commandToExecute\":\"bash oscap.sh ${{ env.vmAdminId }}\"}"
-      - name: Output installation log and copy openscap scanning reports
+      - name: Copy openscap scanning reports
         run: |
           sudo apt-get install -y sshpass
           timeout 1m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${publicIP} 22
-          echo "Output stdout:"
-          result=$(sshpass -p ${{ env.vmAdminPassword }} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${{ env.vmAdminId }}@${publicIP} 'echo "${{ env.vmAdminPassword }}" | sudo -S cat /var/lib/waagent/custom-script/download/0/stdout')
-          echo "$result"
           sshpass -p ${vmAdminPassword} scp ${vmAdminId}@${publicIP}:/home/${vmAdminId}/scan_report_* .
       - name: Upload openscap scanning report before remidation
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
The recent pipeline failure (e.g., [twas-base CICD #31](https://github.com/WASdev/azure.websphere-traditional.image/actions/runs/5394595444/jobs/9795987342)) broke at step `Output installation log and copy openscap scanning reports`:
* ![image](https://github.com/WASdev/azure.websphere-traditional.image/assets/10357495/9af378ff-dbcd-406d-89c3-aee761728fb7)

Based on the error message, the initial guess is that the execution of command `cat /var/lib/waagent/custom-script/download/0/stdout` failed. Then per further investigation, the root cause is that directory `/var/lib/waagent/custom-script/download/0` no longer exists after executing VM extension (`az vm extension set --name CustomScript`) for the 2nd time in step `Harden the VM using OpenSCAP tool`. 

The PR is to fix the issue by outputting the installation log before executing step `Harden the VM using OpenSCAP tool`.

## Testing

3 pipeline workflow runs all completed successfully in my fork with the fix:
* [twas-base CICD](https://github.com/majguo/azure.websphere-traditional.image/actions/runs/5398799614)
* [twas-nd CICD](https://github.com/majguo/azure.websphere-traditional.image/actions/runs/5399138574)
* [ihs CICD](https://github.com/majguo/azure.websphere-traditional.image/actions/runs/5399308931)

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>