### PR TITLE
Ensure workflow delete resources

### DIFF
--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -363,19 +363,19 @@ jobs:
       - name: Delete resource groups during verification
         continue-on-error: true
         run: |
-          vmGroups=( ${{ env.testResourceGroup }}-entitled ${{ env.testResourceGroup }}-unentitled ${{ env.testResourceGroup }}-evaluation )
-          for (( i=0; i<${#vmGroups[@]}; i++ )); do 
-             rgName=${vmGroups[$i]}
-             if az group exists --name $rgName; then
-               echo "Resource group $rgName exists. Deleting..."
-               az group delete --name $rgName --yes --no-wait
-               echo "Resource group $rgName has been scheduled for deletion."
-             else
-               echo "Resource group $rgName does not exist."
-             fi  
-          done
+            vmGroups=( ${{ env.testResourceGroup }}-entitled ${{ env.testResourceGroup }}-unentitled ${{ env.testResourceGroup }}-evaluation )
+            for (( i=0; i<${#vmGroups[@]}; i++ )); do 
+               rgName=${vmGroups[$i]}
+               if $(az group exists --name $rgName); then
+                 echo "Resource group $rgName exists. Deleting..."
+                 az group delete --name $rgName --yes --no-wait
+                 echo "Resource group $rgName has been scheduled for deletion."
+               else
+                 echo "Resource group $rgName does not exist."
+               fi  
+            done
       - name: Delete testResourceGroup
         if: ${{ needs.verify_the_image.result != 'success' }}
         run: |
-          echo "The verify_the_image result is ${{ needs.verify_the_image.result }}, delete the testResourceGroup."
-          az group delete -n ${{ env.testResourceGroup }} --yes --no-wait
+            echo "The verify_the_image result is ${{ needs.verify_the_image.result }}, delete the testResourceGroup."
+            az group delete -n ${{ env.testResourceGroup }} --yes --no-wait

--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -33,8 +33,8 @@ env:
   unEntitledIbmPassword: ${{ secrets.UNENTITLED_IBM_USER_PWD }}
   vmAdminId: ${{ secrets.VM_ADMIN_ID }}
   vmAdminPassword: ${{ secrets.VM_ADMIN_PASSWORD }}
-  testResourceGroup: imageTest${{ github.run_id }}${{ github.run_number }}-ihs
-  vmName: vm${{ github.run_id }}${{ github.run_number }}
+  testResourceGroup: imageTest-${{ github.repository_owner }}-${{ github.run_id }}-${{ github.run_number }}-ihs
+  vmName: vm-${{ github.run_id }}-${{ github.run_number }}
   vhdStorageAccountName: storage${{ github.run_id }}${{ github.run_number }}
   location: eastus
   scriptLocation: https://raw.githubusercontent.com/${{ secrets.USER_NAME }}/azure.websphere-traditional.image/$GITHUB_REF_NAME/ihs/test/

--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -8,8 +8,8 @@ on:
   workflow_dispatch:
     inputs:
       imageVersionNumber:
-        description: 'Must provide image version number'
-        required: true
+        description: 'Provide image version number'
+        required: false
   # Allows you to run this workflow using GitHub APIs
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
   # REPO_NAME=WASdev/azure.websphere-traditional.image
@@ -56,7 +56,8 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-
+    outputs:
+        imageVersionNumber: ${{ steps.setup-env-variables-based-on-dispatch-event.outputs.imageVersionNumber }}
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Get versions of external dependencies
@@ -173,6 +174,11 @@ jobs:
           az vm deallocate --resource-group ${{ env.testResourceGroup }} --name ${{ env.vmName }}
           az vm generalize --resource-group ${{ env.testResourceGroup }} --name ${{ env.vmName }}
           az image create --resource-group ${{ env.testResourceGroup }} --name ${{ env.vmName }} --source ${{ env.vmName }}
+
+  verify_the_image:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
       - name: Verify the image
         run: |
           imageResourceId=$(az image show --name ${{ env.vmName }} --resource-group ${{ env.testResourceGroup }} --query id -o tsv)
@@ -187,13 +193,13 @@ jobs:
           for (( i=0; i<${#vmGroups[@]}; i++ )); do
             rgName=${vmGroups[$i]}
             az group create -n $rgName -l ${{ env.location }}
-            
+
             az deployment group create --resource-group $rgName --name testDeployment \
               --template-file ${{ env.repoName }}/utilities/verifyTemplate.json \
               --parameters deploymentMode=${deploymentModes[$i]} ibmUserId=${ibmUserIds[$i]} ibmUserPwd=${ibmUserPwds[$i]} \
                 imageResourceId=$imageResourceId vmAdminId=${{ env.vmAdminId }} vmAdminPwd=${{ env.vmAdminPassword }} \
                 scriptLocation=${{ env.scriptLocation }}
-            
+
             az group delete -n $rgName --yes --no-wait
           done
       - name: Verify the image with twas-cluster integration-test pipeline
@@ -206,7 +212,7 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${{ env.twasClusterRepo }}/actions/workflows/integration-test.yaml/dispatches \
             -d $(echo $requestData | jq -c)
-          
+
           # Wait until the workflow run starts
           idAndStatus=$(curl -L \
             -H "Accept: application/vnd.github+json" \
@@ -248,7 +254,7 @@ jobs:
               | jq -r '.status')
             echo "Workflow run ${workflowRunId} is ${status}"
           done
-          
+
           # Verify the workflow run result
           jobs=$(curl -L \
             -H "Accept: application/vnd.github+json" \
@@ -262,23 +268,10 @@ jobs:
           else
             echo "twas-cluster integration test workflow run ${workflowRunId} succeeded."
           fi
-      - name: Clean up all resources except for vhd storage account
-        uses: azure/CLI@v1
-        with:
-          azcliversion: ${{ env.azCliVersion }}
-          inlineScript: |
-            az image delete --ids \
-              $(az image show -g ${{ env.testResourceGroup }} -n ${{ env.vmName }} --query id -o tsv)
-            az vm delete --yes --ids \
-              $(az vm show -g ${{ env.testResourceGroup }} -n ${{ env.vmName }} --query id -o tsv)
-            az network nic delete --ids \
-              $(az network nic list -g ${{ env.testResourceGroup }} --query [0].id -o tsv)
-            az network vnet delete --ids \
-              $(az network vnet list -g ${{ env.testResourceGroup }} --query [0].id -o tsv)
-            az network public-ip delete --ids \
-              $(az network public-ip list -g ${{ env.testResourceGroup }} --query [0].id -o tsv)
-            az network nsg delete --ids \
-              $(az network nsg list -g ${{ env.testResourceGroup }} --query [0].id -o tsv)
+  update_sas_url:
+    needs: [build, verify_the_image]
+    runs-on: ubuntu-latest
+    steps:
       - name: Generate SAS url
         id: sas_url
         run: |
@@ -293,7 +286,7 @@ jobs:
           blobStorageEndpoint=$( az storage account show -n ${{ env.vhdStorageAccountName }} -g ${{ env.testResourceGroup }} -o json | jq -r '.primaryEndpoints.blob' )
           osDiskSasUrl=${blobStorageEndpoint}vhds/${{ env.vmName }}.vhd?$sasToken
           dataDiskSasUrl=${blobStorageEndpoint}vhds/${{ env.vmName }}datadisk1.vhd?$sasToken
-          
+
           echo "osDiskSasUrl: ${osDiskSasUrl}, dataDiskSasUrl: ${dataDiskSasUrl}" > sas-url-ihs.txt
           echo "##[set-output name=osDiskSasUrl;]${osDiskSasUrl}"
           echo "##[set-output name=dataDiskSasUrl;]${dataDiskSasUrl}"
@@ -304,6 +297,7 @@ jobs:
           path: sas-url-ihs.txt
       - name: Update offer sas url and version
         uses: microsoft/microsoft-partner-center-github-action@v3.1
+        if: ${{ needs.build.outputs.imageVersionNumber != '' }}
         with:
           offerId: ${{ env.offerId }}
           planId: ${{ env.planId }}
@@ -318,11 +312,37 @@ jobs:
           osDiskSasUrl: ${{steps.sas_url.outputs.osDiskSasUrl}}
           dataDiskSasUrl: ${{steps.sas_url.outputs.dataDiskSasUrl}}
           verbose: "false"
+
   summary:
-    needs: build
+    needs: [build, verify_the_image, update_sas_url]
     runs-on: ubuntu-latest
     steps:
       - name: Output inputs from workflow_dispatch
         run: echo "${{ toJSON(github.event.inputs) }}"
       - name: Output client_payload from repository_dispatch
         run: echo "${{ toJSON(github.event.client_payload) }}"
+
+
+  delete_resource:
+    needs: [summary]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Clean up all resources except for vhd storage account
+        run: |
+            az image delete --ids \
+              $(az image show -g ${{ env.testResourceGroup }} -n ${{ env.vmName }} --query id -o tsv)
+            az vm delete --yes --ids \
+              $(az vm show -g ${{ env.testResourceGroup }} -n ${{ env.vmName }} --query id -o tsv)
+            az network nic delete --ids \
+              $(az network nic list -g ${{ env.testResourceGroup }} --query [0].id -o tsv)
+            az network vnet delete --ids \
+              $(az network vnet list -g ${{ env.testResourceGroup }} --query [0].id -o tsv)
+            az network public-ip delete --ids \
+              $(az network public-ip list -g ${{ env.testResourceGroup }} --query [0].id -o tsv)
+            az network nsg delete --ids \
+              $(az network nsg list -g ${{ env.testResourceGroup }} --query [0].id -o tsv)
+      - name: Delete testResourceGroup
+        if: ${{ needs.verify_the_image.result == 'failure' }}
+        run: |
+          az group delete -n ${{ env.testResourceGroup }} --yes --no-wait

--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -75,7 +75,7 @@ jobs:
           else
             imageVersionNumber=${{ github.event.client_payload.imageVersionNumber }}
           fi
-          echo "##[set-output name=imageVersionNumber;]${imageVersionNumber}"
+          echo "imageVersionNumber=${imageVersionNumber}" >> $GITHUB_OUTPUT
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
@@ -343,6 +343,7 @@ jobs:
             az network nsg delete --ids \
               $(az network nsg list -g ${{ env.testResourceGroup }} --query [0].id -o tsv)
       - name: Delete testResourceGroup
-        if: ${{ needs.verify_the_image.result == 'failure' }}
+        if: ${{ needs.verify_the_image.result != 'success' }}
         run: |
+          echo "The verify_the_image job not success, delete the testResourceGroup."
           az group delete -n ${{ env.testResourceGroup }} --yes --no-wait

--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -277,6 +277,7 @@ jobs:
           else
             echo "twas-cluster integration test workflow run ${workflowRunId} succeeded."
           fi
+
   update_sas_url:
     needs: [build, verify_the_image]
     runs-on: ubuntu-latest
@@ -319,7 +320,7 @@ jobs:
           tenantId: ${{ env.tenantId }}
           secretValue: ${{ env.secretValue }}
           imageType: ${{ env.imageType }}
-          imageVersionNumber: ${{ steps.setup-env-variables-based-on-dispatch-event.outputs.imageVersionNumber }}
+          imageVersionNumber: ${{ needs.build.outputs.imageVersionNumber }}
           operatingSystemFamily: ${{ env.operatingSystemFamily }}
           operatingSystemType: ${{ env.operatingSystemType }}
           osDiskSasUrl: ${{steps.sas_url.outputs.osDiskSasUrl}}

--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -337,7 +337,7 @@ jobs:
         run: echo "${{ toJSON(github.event.client_payload) }}"
 
   delete_resource:
-    needs: [build, verify_the_image, update_sas_url]
+    needs: [ build, verify_the_image, update_sas_url,summary ]
     runs-on: ubuntu-latest
     if: always()
     steps:

--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -179,6 +179,10 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - name: Azure login
+        uses: azure/login@v1
+        with:
+          creds: ${{ env.azureCredentials }}
       - name: Verify the image
         run: |
           imageResourceId=$(az image show --name ${{ env.vmName }} --resource-group ${{ env.testResourceGroup }} --query id -o tsv)
@@ -272,6 +276,10 @@ jobs:
     needs: [build, verify_the_image]
     runs-on: ubuntu-latest
     steps:
+      - name: Azure login
+        uses: azure/login@v1
+        with:
+          creds: ${{ env.azureCredentials }}
       - name: Generate SAS url
         id: sas_url
         run: |
@@ -328,6 +336,10 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     steps:
+      - name: Azure login
+        uses: azure/login@v1
+        with:
+          creds: ${{ env.azureCredentials }}
       - name: Clean up all resources except for vhd storage account
         run: |
             az image delete --ids \

--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -367,7 +367,7 @@ jobs:
              rgName=${vmGroups[$i]}
              if az group exists --name $rgName; then
                echo "Resource group $rgName exists. Deleting..."
-               az group delete --name $RESOURCE_GROUP --yes --no-wait
+               az group delete --name $rgName --yes --no-wait
                echo "Resource group $rgName has been scheduled for deletion."
              else
                echo "Resource group $rgName does not exist."

--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -345,6 +345,7 @@ jobs:
         with:
           creds: ${{ env.azureCredentials }}
       - name: Clean up all resources except for vhd storage account
+        continue-on-error: true
         run: |
             az image delete --ids \
               $(az image show -g ${{ env.testResourceGroup }} -n ${{ env.vmName }} --query id -o tsv)
@@ -359,11 +360,18 @@ jobs:
             az network nsg delete --ids \
               $(az network nsg list -g ${{ env.testResourceGroup }} --query [0].id -o tsv)
       - name: Delete resource groups during verification
+        continue-on-error: true
         run: |
           vmGroups=( ${{ env.testResourceGroup }}-entitled ${{ env.testResourceGroup }}-unentitled ${{ env.testResourceGroup }}-evaluation )
-          for (( i=0; i<${#vmGroups[@]}; i++ )); do
-           rgName=${vmGroups[$i]}
-           az group delete -n $rgName --yes --no-wait
+          for (( i=0; i<${#vmGroups[@]}; i++ )); do 
+             rgName=${vmGroups[$i]}
+             if az group exists --name $rgName; then
+               echo "Resource group $rgName exists. Deleting..."
+               az group delete --name $RESOURCE_GROUP --yes --no-wait
+               echo "Resource group $rgName has been scheduled for deletion."
+             else
+               echo "Resource group $rgName does not exist."
+             fi  
           done
       - name: Delete testResourceGroup
         if: ${{ needs.verify_the_image.result != 'success' }}

--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -336,7 +336,7 @@ jobs:
         run: echo "${{ toJSON(github.event.client_payload) }}"
 
   delete_resource:
-    needs: [summary]
+    needs: [build, verify_the_image, update_sas_url]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -376,5 +376,5 @@ jobs:
       - name: Delete testResourceGroup
         if: ${{ needs.verify_the_image.result != 'success' }}
         run: |
-          echo "The verify_the_image job not success, delete the testResourceGroup."
+          echo "The verify_the_image result is ${{ needs.verify_the_image.result }}, delete the testResourceGroup."
           az group delete -n ${{ env.testResourceGroup }} --yes --no-wait

--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -342,6 +342,13 @@ jobs:
               $(az network public-ip list -g ${{ env.testResourceGroup }} --query [0].id -o tsv)
             az network nsg delete --ids \
               $(az network nsg list -g ${{ env.testResourceGroup }} --query [0].id -o tsv)
+      - name: Delete resource groups during verification
+        run: |
+          vmGroups=( ${{ env.testResourceGroup }}-entitled ${{ env.testResourceGroup }}-unentitled ${{ env.testResourceGroup }}-evaluation )
+          for (( i=0; i<${#vmGroups[@]}; i++ )); do
+           rgName=${vmGroups[$i]}
+           az group delete -n $rgName --yes --no-wait
+          done
       - name: Delete testResourceGroup
         if: ${{ needs.verify_the_image.result != 'success' }}
         run: |

--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -179,6 +179,11 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout ${{ env.repoName }}
+        uses: actions/checkout@v3
+        with:
+          path: ${{ env.repoName }}
+          ref: ${{ github.event.inputs.ref }}
       - name: Azure login
         uses: azure/login@v1
         with:
@@ -329,7 +334,6 @@ jobs:
         run: echo "${{ toJSON(github.event.inputs) }}"
       - name: Output client_payload from repository_dispatch
         run: echo "${{ toJSON(github.event.client_payload) }}"
-
 
   delete_resource:
     needs: [summary]

--- a/.github/workflows/twas-baseBuild.yml
+++ b/.github/workflows/twas-baseBuild.yml
@@ -33,8 +33,8 @@ env:
   unEntitledIbmPassword: ${{ secrets.UNENTITLED_IBM_USER_PWD }}
   vmAdminId: ${{ secrets.VM_ADMIN_ID }}
   vmAdminPassword: ${{ secrets.VM_ADMIN_PASSWORD }}
-  testResourceGroup: imageTest${{ github.run_id }}${{ github.run_number }}-twasBase
-  vmName: vm${{ github.run_id }}${{ github.run_number }}
+  testResourceGroup: imageTest-${{ github.repository_owner }}-${{ github.run_id }}-${{ github.run_number }}-twasBase
+  vmName: vm-${{ github.run_id }}-${{ github.run_number }}
   vhdStorageAccountName: storage${{ github.run_id }}${{ github.run_number }}
   location: eastus
   scriptLocation: https://raw.githubusercontent.com/${{ secrets.USER_NAME }}/azure.websphere-traditional.image/$GITHUB_REF_NAME/twas-base/test/
@@ -327,7 +327,7 @@ jobs:
           verbose: "false"
 
   summary:
-    needs: build
+    needs: [build, verify_the_image, update_sas_url]
     runs-on: ubuntu-latest
     steps:
       - name: Output inputs from workflow_dispatch
@@ -336,7 +336,7 @@ jobs:
         run: echo "${{ toJSON(github.event.client_payload) }}"
 
   delete_resource:
-    needs: [ build, verify_the_image, update_sas_url ]
+    needs: [ build, verify_the_image, update_sas_url,summary ]
     runs-on: ubuntu-latest
     if: always()
     steps:

--- a/.github/workflows/twas-baseBuild.yml
+++ b/.github/workflows/twas-baseBuild.yml
@@ -362,19 +362,19 @@ jobs:
       - name: Delete resource groups during verification
         continue-on-error: true
         run: |
-          vmGroups=( ${{ env.testResourceGroup }}-entitled ${{ env.testResourceGroup }}-unentitled ${{ env.testResourceGroup }}-evaluation )
-          for (( i=0; i<${#vmGroups[@]}; i++ )); do 
-             rgName=${vmGroups[$i]}
-             if az group exists --name $rgName; then
-               echo "Resource group $rgName exists. Deleting..."
-               az group delete --name $rgName --yes --no-wait
-               echo "Resource group $rgName has been scheduled for deletion."
-             else
-               echo "Resource group $rgName does not exist."
-             fi  
-          done
+            vmGroups=( ${{ env.testResourceGroup }}-entitled ${{ env.testResourceGroup }}-unentitled ${{ env.testResourceGroup }}-evaluation )
+            for (( i=0; i<${#vmGroups[@]}; i++ )); do 
+               rgName=${vmGroups[$i]}
+               if $(az group exists --name $rgName); then
+                 echo "Resource group $rgName exists. Deleting..."
+                 az group delete --name $rgName --yes --no-wait
+                 echo "Resource group $rgName has been scheduled for deletion."
+               else
+                 echo "Resource group $rgName does not exist."
+               fi  
+            done
       - name: Delete testResourceGroup
         if: ${{ needs.verify_the_image.result != 'success' }}
         run: |
-          echo "The verify_the_image result is ${{ needs.verify_the_image.result }}, delete the testResourceGroup."
-          az group delete -n ${{ env.testResourceGroup }} --yes --no-wait
+            echo "The verify_the_image result is ${{ needs.verify_the_image.result }}, delete the testResourceGroup."
+            az group delete -n ${{ env.testResourceGroup }} --yes --no-wait

--- a/.github/workflows/twas-baseBuild.yml
+++ b/.github/workflows/twas-baseBuild.yml
@@ -8,8 +8,8 @@ on:
   workflow_dispatch:
     inputs:
       imageVersionNumber:
-        description: 'Must provide image version number'
-        required: true
+        description: 'Provide image version number'
+        required: false
   # Allows you to run this workflow using GitHub APIs
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
   # REPO_NAME=WASdev/azure.websphere-traditional.image
@@ -56,7 +56,8 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-
+    outputs:
+      imageVersionNumber: ${{ steps.setup-env-variables-based-on-dispatch-event.outputs.imageVersionNumber }}
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Get versions of external dependencies
@@ -74,7 +75,7 @@ jobs:
           else
             imageVersionNumber=${{ github.event.client_payload.imageVersionNumber }}
           fi
-          echo "##[set-output name=imageVersionNumber;]${imageVersionNumber}"
+          echo "imageVersionNumber=${imageVersionNumber}" >> $GITHUB_OUTPUT
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
@@ -173,6 +174,20 @@ jobs:
           az vm deallocate --resource-group ${{ env.testResourceGroup }} --name ${{ env.vmName }}
           az vm generalize --resource-group ${{ env.testResourceGroup }} --name ${{ env.vmName }}
           az image create --resource-group ${{ env.testResourceGroup }} --name ${{ env.vmName }} --source ${{ env.vmName }}
+
+  verify_the_image:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout ${{ env.repoName }}
+        uses: actions/checkout@v3
+        with:
+          path: ${{ env.repoName }}
+          ref: ${{ github.event.inputs.ref }}
+      - name: Azure login
+        uses: azure/login@v1
+        with:
+          creds: ${{ env.azureCredentials }}
       - name: Verify the image
         run: |
           imageResourceId=$(az image show --name ${{ env.vmName }} --resource-group ${{ env.testResourceGroup }} --query id -o tsv)
@@ -186,13 +201,13 @@ jobs:
           for (( i=0; i<${#vmGroups[@]}; i++ )); do
             rgName=${vmGroups[$i]}
             az group create -n $rgName -l ${{ env.location }}
-            
+
             az deployment group create --resource-group $rgName --name testDeployment \
               --template-file ${{ env.repoName }}/utilities/verifyTemplate.json \
               --parameters deploymentMode=${deploymentModes[$i]} ibmUserId=${ibmUserIds[$i]} ibmUserPwd=${ibmUserPwds[$i]} \
                 imageResourceId=$imageResourceId vmAdminId=${{ env.vmAdminId }} vmAdminPwd=${{ env.vmAdminPassword }} \
                 scriptLocation=${{ env.scriptLocation }}
-            
+
             az group delete -n $rgName --yes --no-wait
           done
       - name: Verify the image with twas-single integration-test pipeline
@@ -205,7 +220,7 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${{ env.twasSingleRepo }}/actions/workflows/integration-test.yaml/dispatches \
             -d $(echo $requestData | jq -c)
-          
+
           # Wait until the workflow run starts
           idAndStatus=$(curl -L \
             -H "Accept: application/vnd.github+json" \
@@ -247,7 +262,7 @@ jobs:
               | jq -r '.status')
             echo "Workflow run ${workflowRunId} is ${status}"
           done
-          
+
           # Verify the workflow run result
           jobs=$(curl -L \
             -H "Accept: application/vnd.github+json" \
@@ -261,23 +276,15 @@ jobs:
           else
             echo "twas-single integration test workflow run ${workflowRunId} succeeded."
           fi
-      - name: Clean up all resources except for vhd storage account
-        uses: azure/CLI@v1
+      
+  update_sas_url:
+    needs: [ build, verify_the_image ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Azure login
+        uses: azure/login@v1
         with:
-          azcliversion: ${{ env.azCliVersion }}
-          inlineScript: |
-            az image delete --ids \
-              $(az image show -g ${{ env.testResourceGroup }} -n ${{ env.vmName }} --query id -o tsv)
-            az vm delete --yes --ids \
-              $(az vm show -g ${{ env.testResourceGroup }} -n ${{ env.vmName }} --query id -o tsv)
-            az network nic delete --ids \
-              $(az network nic list -g ${{ env.testResourceGroup }} --query [0].id -o tsv)
-            az network vnet delete --ids \
-              $(az network vnet list -g ${{ env.testResourceGroup }} --query [0].id -o tsv)
-            az network public-ip delete --ids \
-              $(az network public-ip list -g ${{ env.testResourceGroup }} --query [0].id -o tsv)
-            az network nsg delete --ids \
-              $(az network nsg list -g ${{ env.testResourceGroup }} --query [0].id -o tsv)
+          creds: ${{ env.azureCredentials }}
       - name: Generate SAS url
         id: sas_url
         run: |
@@ -303,6 +310,7 @@ jobs:
           path: sas-url-twasbase.txt
       - name: Update offer sas url and version
         uses: microsoft/microsoft-partner-center-github-action@v3.1
+        if: ${{ needs.build.outputs.imageVersionNumber != '' }}
         with:
           offerId: ${{ env.offerId }}
           planId: ${{ env.planId }}
@@ -310,13 +318,14 @@ jobs:
           tenantId: ${{ env.tenantId }}
           secretValue: ${{ env.secretValue }}
           imageType: ${{ env.imageType }}
-          imageVersionNumber: ${{ steps.setup-env-variables-based-on-dispatch-event.outputs.imageVersionNumber }}
+          imageVersionNumber: ${{ needs.build.outputs.imageVersionNumber }}
           offerType: ${{ env.offerType }}
           operatingSystemFamily: ${{ env.operatingSystemFamily }}
           operatingSystemType: ${{ env.operatingSystemType }}
           osDiskSasUrl: ${{steps.sas_url.outputs.osDiskSasUrl}}
           dataDiskSasUrl: ${{steps.sas_url.outputs.dataDiskSasUrl}}
           verbose: "false"
+
   summary:
     needs: build
     runs-on: ubuntu-latest
@@ -325,3 +334,47 @@ jobs:
         run: echo "${{ toJSON(github.event.inputs) }}"
       - name: Output client_payload from repository_dispatch
         run: echo "${{ toJSON(github.event.client_payload) }}"
+
+  delete_resource:
+    needs: [ build, verify_the_image, update_sas_url ]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Azure login
+        uses: azure/login@v1
+        with:
+          creds: ${{ env.azureCredentials }}
+      - name: Clean up all resources except for vhd storage account
+        continue-on-error: true
+        run: |
+            az image delete --ids \
+              $(az image show -g ${{ env.testResourceGroup }} -n ${{ env.vmName }} --query id -o tsv)
+            az vm delete --yes --ids \
+              $(az vm show -g ${{ env.testResourceGroup }} -n ${{ env.vmName }} --query id -o tsv)
+            az network nic delete --ids \
+              $(az network nic list -g ${{ env.testResourceGroup }} --query [0].id -o tsv)
+            az network vnet delete --ids \
+              $(az network vnet list -g ${{ env.testResourceGroup }} --query [0].id -o tsv)
+            az network public-ip delete --ids \
+              $(az network public-ip list -g ${{ env.testResourceGroup }} --query [0].id -o tsv)
+            az network nsg delete --ids \
+              $(az network nsg list -g ${{ env.testResourceGroup }} --query [0].id -o tsv)
+      - name: Delete resource groups during verification
+        continue-on-error: true
+        run: |
+          vmGroups=( ${{ env.testResourceGroup }}-entitled ${{ env.testResourceGroup }}-unentitled ${{ env.testResourceGroup }}-evaluation )
+          for (( i=0; i<${#vmGroups[@]}; i++ )); do 
+             rgName=${vmGroups[$i]}
+             if az group exists --name $rgName; then
+               echo "Resource group $rgName exists. Deleting..."
+               az group delete --name $rgName --yes --no-wait
+               echo "Resource group $rgName has been scheduled for deletion."
+             else
+               echo "Resource group $rgName does not exist."
+             fi  
+          done
+      - name: Delete testResourceGroup
+        if: ${{ needs.verify_the_image.result != 'success' }}
+        run: |
+          echo "The verify_the_image result is ${{ needs.verify_the_image.result }}, delete the testResourceGroup."
+          az group delete -n ${{ env.testResourceGroup }} --yes --no-wait

--- a/.github/workflows/twas-ndBuild.yml
+++ b/.github/workflows/twas-ndBuild.yml
@@ -366,7 +366,7 @@ jobs:
             vmGroups=( ${{ env.testResourceGroup }}-entitled ${{ env.testResourceGroup }}-unentitled ${{ env.testResourceGroup }}-evaluation )
             for (( i=0; i<${#vmGroups[@]}; i++ )); do 
                rgName=${vmGroups[$i]}
-               if az group exists --name $rgName; then
+               if $(az group exists --name $rgName); then
                  echo "Resource group $rgName exists. Deleting..."
                  az group delete --name $rgName --yes --no-wait
                  echo "Resource group $rgName has been scheduled for deletion."

--- a/.github/workflows/twas-ndBuild.yml
+++ b/.github/workflows/twas-ndBuild.yml
@@ -8,8 +8,8 @@ on:
   workflow_dispatch:
     inputs:
       imageVersionNumber:
-        description: 'Must provide image version number'
-        required: true
+        description: 'Provide image version number'
+        required: false
   # Allows you to run this workflow using GitHub APIs
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
   # REPO_NAME=WASdev/azure.websphere-traditional.image
@@ -56,7 +56,8 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-
+    outputs:
+        imageVersionNumber: ${{ steps.setup-env-variables-based-on-dispatch-event.outputs.imageVersionNumber }}
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Get versions of external dependencies
@@ -173,12 +174,26 @@ jobs:
           az vm deallocate --resource-group ${{ env.testResourceGroup }} --name ${{ env.vmName }}
           az vm generalize --resource-group ${{ env.testResourceGroup }} --name ${{ env.vmName }}
           az image create --resource-group ${{ env.testResourceGroup }} --name ${{ env.vmName }} --source ${{ env.vmName }}
+
+  verify_the_image:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout ${{ env.repoName }}
+        uses: actions/checkout@v3
+        with:
+          path: ${{ env.repoName }}
+          ref: ${{ github.event.inputs.ref }}
+      - name: Azure login
+        uses: azure/login@v1
+        with:
+          creds: ${{ env.azureCredentials }}
       - name: Verify the image
         run: |
           imageResourceId=$(az image show --name ${{ env.vmName }} --resource-group ${{ env.testResourceGroup }} --query id -o tsv)
           echo "ndImageResourceId=${imageResourceId}" >> $GITHUB_ENV
           echo "ihsImageResourceId=" >> $GITHUB_ENV
-          
+
           # Deploy VMs using different IBMids and verify installation
           vmGroups=( ${{ env.testResourceGroup }}-entitled ${{ env.testResourceGroup }}-unentitled ${{ env.testResourceGroup }}-evaluation )
           deploymentModes=( Entitled Unentitled Evaluation )
@@ -187,13 +202,13 @@ jobs:
           for (( i=0; i<${#vmGroups[@]}; i++ )); do
             rgName=${vmGroups[$i]}
             az group create -n $rgName -l ${{ env.location }}
-            
+
             az deployment group create --resource-group $rgName --name testDeployment \
               --template-file ${{ env.repoName }}/utilities/verifyTemplate.json \
               --parameters deploymentMode=${deploymentModes[$i]} ibmUserId=${ibmUserIds[$i]} ibmUserPwd=${ibmUserPwds[$i]} \
                 imageResourceId=$imageResourceId vmAdminId=${{ env.vmAdminId }} vmAdminPwd=${{ env.vmAdminPassword }} \
                 scriptLocation=${{ env.scriptLocation }}
-            
+
             az group delete -n $rgName --yes --no-wait
           done
       - name: Verify the image with twas-cluster integration-test pipeline
@@ -206,7 +221,7 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${{ env.twasClusterRepo }}/actions/workflows/integration-test.yaml/dispatches \
             -d $(echo $requestData | jq -c)
-          
+
           # Wait until the workflow run starts
           idAndStatus=$(curl -L \
             -H "Accept: application/vnd.github+json" \
@@ -248,7 +263,7 @@ jobs:
               | jq -r '.status')
             echo "Workflow run ${workflowRunId} is ${status}"
           done
-          
+
           # Verify the workflow run result
           jobs=$(curl -L \
             -H "Accept: application/vnd.github+json" \
@@ -262,23 +277,15 @@ jobs:
           else
             echo "twas-cluster integration test workflow run ${workflowRunId} succeeded."
           fi
-      - name: Clean up all resources except for vhd storage account
-        uses: azure/CLI@v1
+
+  update_sas_url:
+    needs: [ build, verify_the_image ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Azure login
+        uses: azure/login@v1
         with:
-          azcliversion: ${{ env.azCliVersion }}
-          inlineScript: |
-            az image delete --ids \
-              $(az image show -g ${{ env.testResourceGroup }} -n ${{ env.vmName }} --query id -o tsv)
-            az vm delete --yes --ids \
-              $(az vm show -g ${{ env.testResourceGroup }} -n ${{ env.vmName }} --query id -o tsv)
-            az network nic delete --ids \
-              $(az network nic list -g ${{ env.testResourceGroup }} --query [0].id -o tsv)
-            az network vnet delete --ids \
-              $(az network vnet list -g ${{ env.testResourceGroup }} --query [0].id -o tsv)
-            az network public-ip delete --ids \
-              $(az network public-ip list -g ${{ env.testResourceGroup }} --query [0].id -o tsv)
-            az network nsg delete --ids \
-              $(az network nsg list -g ${{ env.testResourceGroup }} --query [0].id -o tsv)
+          creds: ${{ env.azureCredentials }}
       - name: Generate SAS url
         id: sas_url
         run: |
@@ -293,7 +300,7 @@ jobs:
           blobStorageEndpoint=$( az storage account show -n ${{ env.vhdStorageAccountName }} -g ${{ env.testResourceGroup }} -o json | jq -r '.primaryEndpoints.blob' )
           osDiskSasUrl=${blobStorageEndpoint}vhds/${{ env.vmName }}.vhd?$sasToken
           dataDiskSasUrl=${blobStorageEndpoint}vhds/${{ env.vmName }}datadisk1.vhd?$sasToken
-          
+
           echo "osDiskSasUrl: ${osDiskSasUrl}, dataDiskSasUrl: ${dataDiskSasUrl}" > sas-url-twasnd.txt
           echo "##[set-output name=osDiskSasUrl;]${osDiskSasUrl}"
           echo "##[set-output name=dataDiskSasUrl;]${dataDiskSasUrl}"
@@ -304,6 +311,7 @@ jobs:
           path: sas-url-twasnd.txt
       - name: Update offer sas url and version
         uses: microsoft/microsoft-partner-center-github-action@v3.1
+        if: ${{ needs.build.outputs.imageVersionNumber != '' }}
         with:
           offerId: ${{ env.offerId }}
           planId: ${{ env.planId }}
@@ -312,12 +320,13 @@ jobs:
           tenantId: ${{ env.tenantId }}
           secretValue: ${{ env.secretValue }}
           imageType: ${{ env.imageType }}
-          imageVersionNumber: ${{ steps.setup-env-variables-based-on-dispatch-event.outputs.imageVersionNumber }}
+          imageVersionNumber: ${{ needs.build.outputs.imageVersionNumber }}
           operatingSystemFamily: ${{ env.operatingSystemFamily }}
           operatingSystemType: ${{ env.operatingSystemType }}
           osDiskSasUrl: ${{steps.sas_url.outputs.osDiskSasUrl}}
           dataDiskSasUrl: ${{steps.sas_url.outputs.dataDiskSasUrl}}
           verbose: "false"
+
   summary:
     needs: build
     runs-on: ubuntu-latest
@@ -326,3 +335,47 @@ jobs:
         run: echo "${{ toJSON(github.event.inputs) }}"
       - name: Output client_payload from repository_dispatch
         run: echo "${{ toJSON(github.event.client_payload) }}"
+
+  delete_resource:
+    needs: [ build, verify_the_image, update_sas_url ]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Azure login
+        uses: azure/login@v1
+        with:
+          creds: ${{ env.azureCredentials }}
+      - name: Clean up all resources except for vhd storage account
+        continue-on-error: true
+        run: |          
+            az image delete --ids \
+              $(az image show -g ${{ env.testResourceGroup }} -n ${{ env.vmName }} --query id -o tsv)
+            az vm delete --yes --ids \
+              $(az vm show -g ${{ env.testResourceGroup }} -n ${{ env.vmName }} --query id -o tsv)
+            az network nic delete --ids \
+              $(az network nic list -g ${{ env.testResourceGroup }} --query [0].id -o tsv)
+            az network vnet delete --ids \
+              $(az network vnet list -g ${{ env.testResourceGroup }} --query [0].id -o tsv)
+            az network public-ip delete --ids \
+              $(az network public-ip list -g ${{ env.testResourceGroup }} --query [0].id -o tsv)
+            az network nsg delete --ids \
+              $(az network nsg list -g ${{ env.testResourceGroup }} --query [0].id -o tsv)
+      - name: Delete resource groups during verification
+        continue-on-error: true
+        run: |
+            vmGroups=( ${{ env.testResourceGroup }}-entitled ${{ env.testResourceGroup }}-unentitled ${{ env.testResourceGroup }}-evaluation )
+            for (( i=0; i<${#vmGroups[@]}; i++ )); do 
+               rgName=${vmGroups[$i]}
+               if az group exists --name $rgName; then
+                 echo "Resource group $rgName exists. Deleting..."
+                 az group delete --name $rgName --yes --no-wait
+                 echo "Resource group $rgName has been scheduled for deletion."
+               else
+                 echo "Resource group $rgName does not exist."
+               fi  
+            done
+      - name: Delete testResourceGroup
+        if: ${{ needs.verify_the_image.result != 'success' }}
+        run: |
+            echo "The verify_the_image result is ${{ needs.verify_the_image.result }}, delete the testResourceGroup."
+            az group delete -n ${{ env.testResourceGroup }} --yes --no-wait    

--- a/.github/workflows/twas-ndBuild.yml
+++ b/.github/workflows/twas-ndBuild.yml
@@ -33,8 +33,8 @@ env:
   unEntitledIbmPassword: ${{ secrets.UNENTITLED_IBM_USER_PWD }}
   vmAdminId: ${{ secrets.VM_ADMIN_ID }}
   vmAdminPassword: ${{ secrets.VM_ADMIN_PASSWORD }}
-  testResourceGroup: imageTest${{ github.run_id }}${{ github.run_number }}-twasND
-  vmName: vm${{ github.run_id }}${{ github.run_number }}
+  testResourceGroup: imageTest-${{ github.repository_owner }}-${{ github.run_id }}-${{ github.run_number }}-twasND
+  vmName: vm-${{ github.run_id }}-${{ github.run_number }}
   vhdStorageAccountName: storage${{ github.run_id }}${{ github.run_number }}
   location: eastus
   scriptLocation: https://raw.githubusercontent.com/${{ secrets.USER_NAME }}/azure.websphere-traditional.image/$GITHUB_REF_NAME/twas-nd/test/
@@ -328,7 +328,7 @@ jobs:
           verbose: "false"
 
   summary:
-    needs: build
+    needs: [build, verify_the_image, update_sas_url]
     runs-on: ubuntu-latest
     steps:
       - name: Output inputs from workflow_dispatch
@@ -337,7 +337,7 @@ jobs:
         run: echo "${{ toJSON(github.event.client_payload) }}"
 
   delete_resource:
-    needs: [ build, verify_the_image, update_sas_url ]
+    needs: [ build, verify_the_image, update_sas_url,summary ]
     runs-on: ubuntu-latest
     if: always()
     steps:

--- a/docs/howto-update-image.md
+++ b/docs/howto-update-image.md
@@ -79,7 +79,9 @@ Now that you have satisfied the preconditions **in this repository and related r
 
 1. Decide on a value for the `imageVersionNumber` parameter. The required syntax for this value is `9.0.YYYYMMDD`. Where `YYYYMMDD` is usually today's date.
 1. Visit the [GitHub Actions page for the twas-base CICD workflow](https://github.com/WASdev/azure.websphere-traditional.image/actions/workflows/twas-baseBuild.yml).
-1. Select the **Run workflow** dropdown. Enter the value for `imageVersionNumber` under `Must provide image version number`
+1. Select the **Run workflow** dropdown. Enter the value for `imageVersionNumber` under `Provide image version number`
+    - Please note that the `imageVersionNumber` must be provided if you want to publish the image to Partner Center. 
+    - If you do not provide `imageVersionNumber` value, the workflow will only used for test purpose.    
 1. Select **Run workflow**.
 1. Observe the execution of the jobs in the workflow.
    - One very important job is **Verify the image**. This job calls another workflow, on the related repository for the Azure Application, but the VM image created by the calling workflow is taken as input to this called workflow.


### PR DESCRIPTION
## Updates
1. Rename testResourceGroup with pattern: `${prefix}-${{ github.repository_owner }}-${{ github.run_id }}-${{ github.run_number }}`
1. Refactor workflows to ensure at the end of the workflow, the azure resources will be deleted.
2. Make [imageVersionNumber ](https://github.com/WASdev/azure.websphere-traditional.image/pull/105/files#diff-d3b6f66387b4f43de178e32bab5b0dcc786385e24a847110f40484d4e3a3f121R11) optional, the [sas_url ](https://github.com/WASdev/azure.websphere-traditional.image/blob/815375f05f4577e681492318376acabd048da760/.github/workflows/ihsBuild.yml#L314)will not be updated if it is empty.
3. Delete all resources if the image verification [fails](https://github.com/WASdev/azure.websphere-traditional.image/blob/815375f05f4577e681492318376acabd048da760/.github/workflows/ihsBuild.yml#L378).
## Test
- ✅[twas-nd CICD](https://github.com/azure-javaee/azure.websphere-traditional.image/actions/runs/8003531994)
    ![image](https://github.com/WASdev/azure.websphere-traditional.image/assets/4465723/f3c14c5b-c6eb-4d17-bdf9-a4eadde8ed88)
