### PR TITLE
Remove azure javaee in workflows

### DIFF
--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -375,7 +375,7 @@ jobs:
                fi  
             done
       - name: Delete testResourceGroup
-        if: ${{ needs.verify_the_image.result != 'success' }}
+        if: ${{ needs.verify_the_image.result != 'success' || needs.build.outputs.imageVersionNumber == '' }}
         run: |
             echo "The verify_the_image result is ${{ needs.verify_the_image.result }}, delete the testResourceGroup."
             az group delete -n ${{ env.testResourceGroup }} --yes --no-wait

--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -64,6 +64,7 @@ jobs:
         run: |
           curl -Lo external-deps-versions.properties https://raw.githubusercontent.com/Azure/azure-javaee-iaas/main/external-deps-versions.properties
           source external-deps-versions.properties
+          echo "refArmttk=${ARM_TTK_REFERENCE}" >> $GITHUB_ENV
           echo "azCliVersion=${AZ_CLI_VERSION}" >> $GITHUB_ENV
       - name: Setup environment variables
         id: setup-env-variables-based-on-dispatch-event
@@ -90,11 +91,12 @@ jobs:
         run: |
           echo "MAVEN_USERNAME=${MAVEN_USERNAME}" >> "$GITHUB_ENV"
           echo "MAVEN_TOKEN=${MAVEN_TOKEN}" >> "$GITHUB_ENV"
-      - name: Download arm-ttk used in partner center pipeline
-        shell: bash
-        run: |
-          wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
-          unzip arm-template-toolkit.zip -d arm-ttk
+      - name: Checkout arm-ttk
+        uses: actions/checkout@v3
+        with:
+          repository: Azure/arm-ttk
+          path: arm-ttk
+          ref: ${{ env.refArmttk }}
       - name: Checkout ${{ env.repoName }}
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -65,8 +65,6 @@ jobs:
           curl -Lo external-deps-versions.properties https://raw.githubusercontent.com/Azure/azure-javaee-iaas/main/external-deps-versions.properties
           source external-deps-versions.properties
           echo "azCliVersion=${AZ_CLI_VERSION}" >> $GITHUB_ENV
-          echo "refArmttk=${ARM_TTK_REFERENCE}" >> $GITHUB_ENV
-          echo "refJavaee=${AZURE_JAVAEE_IAAS_REFERENCE}" >> $GITHUB_ENV
       - name: Setup environment variables
         id: setup-env-variables-based-on-dispatch-event
         run: |
@@ -81,25 +79,30 @@ jobs:
         with:
           distribution: 'microsoft'
           java-version: '11'
-      - name: Checkout azure-javaee-iaas
-        uses: actions/checkout@v3
-        with:
-          repository: Azure/azure-javaee-iaas
-          path: azure-javaee-iaas
-          ref: ${{ env.refJavaee }}
-      - name: Checkout arm-ttk
-        uses: actions/checkout@v3
-        with:
-          repository: Azure/arm-ttk
-          path: arm-ttk
-          ref: ${{ env.refArmttk }}
+          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+          server-username: MAVEN_USERNAME # env variable for username
+          server-password: MAVEN_TOKEN # env variable for token
+
+      - name: Set Maven env
+        env:
+          MAVEN_USERNAME: github
+          MAVEN_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          echo "MAVEN_USERNAME=${MAVEN_USERNAME}" >> "$GITHUB_ENV"
+          echo "MAVEN_TOKEN=${MAVEN_TOKEN}" >> "$GITHUB_ENV"
+
+      - name: Download arm-ttk used in partner center pipeline
+        shell: bash
+        run: |
+          wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
+          unzip arm-template-toolkit.zip -d arm-ttk
+
       - name: Checkout ${{ env.repoName }}
         uses: actions/checkout@v3
         with:
           path: ${{ env.repoName }}
           ref: ${{ github.event.inputs.ref }}
-      - name: Build azure-javaee-iaas
-        run: mvn -DskipTests clean install --file azure-javaee-iaas/pom.xml
       - name: Azure login
         uses: azure/login@v1
         with:

--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -10,6 +10,16 @@ on:
       imageVersionNumber:
         description: 'Provide image version number'
         required: false
+      updateOfferArtifact:
+        description: 'Update offer artifact'
+        required: true
+        type: boolean
+        default: true
+      skipIntegrationTests:
+        description: 'If true, do not call integration tests in other repositories.'
+        required: true
+        type: boolean
+        default: false
   # Allows you to run this workflow using GitHub APIs
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
   # REPO_NAME=WASdev/azure.websphere-traditional.image
@@ -212,6 +222,7 @@ jobs:
             az group delete -n $rgName --yes --no-wait
           done
       - name: Verify the image with twas-cluster integration-test pipeline
+        if: ${{ !inputs.skipIntegrationTests }}
         run: |
           # Trigger the workflow run
           requestData={\"ref\":\"${GITHUB_REF_NAME}\",\"inputs\":{\"databaseType\":\"none\",\"ndImageResourceId\":\"${ndImageResourceId}\",\"ihsImageResourceId\":\"${ihsImageResourceId}\"}}
@@ -311,7 +322,7 @@ jobs:
           path: sas-url-ihs.txt
       - name: Update offer sas url and version
         uses: microsoft/microsoft-partner-center-github-action@v3.1
-        if: ${{ needs.build.outputs.imageVersionNumber != '' }}
+        if: ${{ inputs.updateOfferArtifact == true && needs.build.outputs.imageVersionNumber != '' }}
         with:
           offerId: ${{ env.offerId }}
           planId: ${{ env.planId }}

--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -82,7 +82,6 @@ jobs:
           server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
           server-username: MAVEN_USERNAME # env variable for username
           server-password: MAVEN_TOKEN # env variable for token
-
       - name: Set Maven env
         env:
           MAVEN_USERNAME: github
@@ -91,13 +90,11 @@ jobs:
         run: |
           echo "MAVEN_USERNAME=${MAVEN_USERNAME}" >> "$GITHUB_ENV"
           echo "MAVEN_TOKEN=${MAVEN_TOKEN}" >> "$GITHUB_ENV"
-
       - name: Download arm-ttk used in partner center pipeline
         shell: bash
         run: |
           wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
           unzip arm-template-toolkit.zip -d arm-ttk
-
       - name: Checkout ${{ env.repoName }}
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -64,7 +64,6 @@ jobs:
         run: |
           curl -Lo external-deps-versions.properties https://raw.githubusercontent.com/Azure/azure-javaee-iaas/main/external-deps-versions.properties
           source external-deps-versions.properties
-          echo "refArmttk=${ARM_TTK_REFERENCE}" >> $GITHUB_ENV
           echo "azCliVersion=${AZ_CLI_VERSION}" >> $GITHUB_ENV
       - name: Setup environment variables
         id: setup-env-variables-based-on-dispatch-event
@@ -96,7 +95,6 @@ jobs:
         with:
           repository: Azure/arm-ttk
           path: arm-ttk
-          ref: ${{ env.refArmttk }}
       - name: Checkout ${{ env.repoName }}
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/twas-baseBuild.yml
+++ b/.github/workflows/twas-baseBuild.yml
@@ -64,6 +64,7 @@ jobs:
         run: |
           curl -Lo external-deps-versions.properties https://raw.githubusercontent.com/Azure/azure-javaee-iaas/main/external-deps-versions.properties
           source external-deps-versions.properties
+          echo "refArmttk=${ARM_TTK_REFERENCE}" >> $GITHUB_ENV
           echo "azCliVersion=${AZ_CLI_VERSION}" >> $GITHUB_ENV
       - name: Setup environment variables
         id: setup-env-variables-based-on-dispatch-event
@@ -90,11 +91,12 @@ jobs:
         run: |
           echo "MAVEN_USERNAME=${MAVEN_USERNAME}" >> "$GITHUB_ENV"
           echo "MAVEN_TOKEN=${MAVEN_TOKEN}" >> "$GITHUB_ENV"
-      - name: Download arm-ttk used in partner center pipeline
-        shell: bash
-        run: |
-          wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
-          unzip arm-template-toolkit.zip -d arm-ttk
+      - name: Checkout arm-ttk
+        uses: actions/checkout@v3
+        with:
+          repository: Azure/arm-ttk
+          path: arm-ttk
+          ref: ${{ env.refArmttk }}
       - name: Checkout ${{ env.repoName }}
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/twas-baseBuild.yml
+++ b/.github/workflows/twas-baseBuild.yml
@@ -82,7 +82,6 @@ jobs:
           server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
           server-username: MAVEN_USERNAME # env variable for username
           server-password: MAVEN_TOKEN # env variable for token
-
       - name: Set Maven env
         env:
           MAVEN_USERNAME: github
@@ -91,19 +90,16 @@ jobs:
         run: |
           echo "MAVEN_USERNAME=${MAVEN_USERNAME}" >> "$GITHUB_ENV"
           echo "MAVEN_TOKEN=${MAVEN_TOKEN}" >> "$GITHUB_ENV"
-
       - name: Download arm-ttk used in partner center pipeline
         shell: bash
         run: |
           wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
           unzip arm-template-toolkit.zip -d arm-ttk
-
       - name: Checkout ${{ env.repoName }}
         uses: actions/checkout@v3
         with:
           path: ${{ env.repoName }}
           ref: ${{ github.event.inputs.ref }}
-
       - name: Azure login
         uses: azure/login@v1
         with:

--- a/.github/workflows/twas-baseBuild.yml
+++ b/.github/workflows/twas-baseBuild.yml
@@ -374,7 +374,7 @@ jobs:
                fi  
             done
       - name: Delete testResourceGroup
-        if: ${{ needs.verify_the_image.result != 'success' }}
+        if: ${{ needs.verify_the_image.result != 'success' || needs.build.outputs.imageVersionNumber == '' }}
         run: |
             echo "The verify_the_image result is ${{ needs.verify_the_image.result }}, delete the testResourceGroup."
             az group delete -n ${{ env.testResourceGroup }} --yes --no-wait

--- a/.github/workflows/twas-baseBuild.yml
+++ b/.github/workflows/twas-baseBuild.yml
@@ -65,8 +65,6 @@ jobs:
           curl -Lo external-deps-versions.properties https://raw.githubusercontent.com/Azure/azure-javaee-iaas/main/external-deps-versions.properties
           source external-deps-versions.properties
           echo "azCliVersion=${AZ_CLI_VERSION}" >> $GITHUB_ENV
-          echo "refArmttk=${ARM_TTK_REFERENCE}" >> $GITHUB_ENV
-          echo "refJavaee=${AZURE_JAVAEE_IAAS_REFERENCE}" >> $GITHUB_ENV
       - name: Setup environment variables
         id: setup-env-variables-based-on-dispatch-event
         run: |
@@ -81,25 +79,31 @@ jobs:
         with:
           distribution: 'microsoft'
           java-version: '11'
-      - name: Checkout azure-javaee-iaas
-        uses: actions/checkout@v3
-        with:
-          repository: Azure/azure-javaee-iaas
-          path: azure-javaee-iaas
-          ref: ${{ env.refJavaee }}
-      - name: Checkout arm-ttk
-        uses: actions/checkout@v3
-        with:
-          repository: Azure/arm-ttk
-          path: arm-ttk
-          ref: ${{ env.refArmttk }}
+          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+          server-username: MAVEN_USERNAME # env variable for username
+          server-password: MAVEN_TOKEN # env variable for token
+
+      - name: Set Maven env
+        env:
+          MAVEN_USERNAME: github
+          MAVEN_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          echo "MAVEN_USERNAME=${MAVEN_USERNAME}" >> "$GITHUB_ENV"
+          echo "MAVEN_TOKEN=${MAVEN_TOKEN}" >> "$GITHUB_ENV"
+
+      - name: Download arm-ttk used in partner center pipeline
+        shell: bash
+        run: |
+          wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
+          unzip arm-template-toolkit.zip -d arm-ttk
+
       - name: Checkout ${{ env.repoName }}
         uses: actions/checkout@v3
         with:
           path: ${{ env.repoName }}
           ref: ${{ github.event.inputs.ref }}
-      - name: Build azure-javaee-iaas
-        run: mvn -DskipTests clean install --file azure-javaee-iaas/pom.xml
+
       - name: Azure login
         uses: azure/login@v1
         with:

--- a/.github/workflows/twas-baseBuild.yml
+++ b/.github/workflows/twas-baseBuild.yml
@@ -64,7 +64,6 @@ jobs:
         run: |
           curl -Lo external-deps-versions.properties https://raw.githubusercontent.com/Azure/azure-javaee-iaas/main/external-deps-versions.properties
           source external-deps-versions.properties
-          echo "refArmttk=${ARM_TTK_REFERENCE}" >> $GITHUB_ENV
           echo "azCliVersion=${AZ_CLI_VERSION}" >> $GITHUB_ENV
       - name: Setup environment variables
         id: setup-env-variables-based-on-dispatch-event
@@ -96,7 +95,6 @@ jobs:
         with:
           repository: Azure/arm-ttk
           path: arm-ttk
-          ref: ${{ env.refArmttk }}
       - name: Checkout ${{ env.repoName }}
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/twas-ndBuild.yml
+++ b/.github/workflows/twas-ndBuild.yml
@@ -375,7 +375,7 @@ jobs:
                fi  
             done
       - name: Delete testResourceGroup
-        if: ${{ needs.verify_the_image.result != 'success' }}
+        if: ${{ needs.verify_the_image.result != 'success' || needs.build.outputs.imageVersionNumber == '' }}
         run: |
             echo "The verify_the_image result is ${{ needs.verify_the_image.result }}, delete the testResourceGroup."
             az group delete -n ${{ env.testResourceGroup }} --yes --no-wait    

--- a/.github/workflows/twas-ndBuild.yml
+++ b/.github/workflows/twas-ndBuild.yml
@@ -64,6 +64,7 @@ jobs:
         run: |
           curl -Lo external-deps-versions.properties https://raw.githubusercontent.com/Azure/azure-javaee-iaas/main/external-deps-versions.properties
           source external-deps-versions.properties
+          echo "refArmttk=${ARM_TTK_REFERENCE}" >> $GITHUB_ENV
           echo "azCliVersion=${AZ_CLI_VERSION}" >> $GITHUB_ENV
       - name: Setup environment variables
         id: setup-env-variables-based-on-dispatch-event
@@ -90,11 +91,12 @@ jobs:
         run: |
           echo "MAVEN_USERNAME=${MAVEN_USERNAME}" >> "$GITHUB_ENV"
           echo "MAVEN_TOKEN=${MAVEN_TOKEN}" >> "$GITHUB_ENV"
-      - name: Download arm-ttk used in partner center pipeline
-        shell: bash
-        run: |
-          wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
-          unzip arm-template-toolkit.zip -d arm-ttk
+      - name: Checkout arm-ttk
+        uses: actions/checkout@v3
+        with:
+          repository: Azure/arm-ttk
+          path: arm-ttk
+          ref: ${{ env.refArmttk }}
       - name: Checkout ${{ env.repoName }}
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/twas-ndBuild.yml
+++ b/.github/workflows/twas-ndBuild.yml
@@ -65,8 +65,6 @@ jobs:
           curl -Lo external-deps-versions.properties https://raw.githubusercontent.com/Azure/azure-javaee-iaas/main/external-deps-versions.properties
           source external-deps-versions.properties
           echo "azCliVersion=${AZ_CLI_VERSION}" >> $GITHUB_ENV
-          echo "refArmttk=${ARM_TTK_REFERENCE}" >> $GITHUB_ENV
-          echo "refJavaee=${AZURE_JAVAEE_IAAS_REFERENCE}" >> $GITHUB_ENV
       - name: Setup environment variables
         id: setup-env-variables-based-on-dispatch-event
         run: |
@@ -81,25 +79,30 @@ jobs:
         with:
           distribution: 'microsoft'
           java-version: '11'
-      - name: Checkout azure-javaee-iaas
-        uses: actions/checkout@v3
-        with:
-          repository: Azure/azure-javaee-iaas
-          path: azure-javaee-iaas
-          ref: ${{ env.refJavaee }}
-      - name: Checkout arm-ttk
-        uses: actions/checkout@v3
-        with:
-          repository: Azure/arm-ttk
-          path: arm-ttk
-          ref: ${{ env.refArmttk }}
+          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+          server-username: MAVEN_USERNAME # env variable for username
+          server-password: MAVEN_TOKEN # env variable for token
+
+      - name: Set Maven env
+        env:
+          MAVEN_USERNAME: github
+          MAVEN_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          echo "MAVEN_USERNAME=${MAVEN_USERNAME}" >> "$GITHUB_ENV"
+          echo "MAVEN_TOKEN=${MAVEN_TOKEN}" >> "$GITHUB_ENV"
+
+      - name: Download arm-ttk used in partner center pipeline
+        shell: bash
+        run: |
+          wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
+          unzip arm-template-toolkit.zip -d arm-ttk
+
       - name: Checkout ${{ env.repoName }}
         uses: actions/checkout@v3
         with:
           path: ${{ env.repoName }}
           ref: ${{ github.event.inputs.ref }}
-      - name: Build azure-javaee-iaas
-        run: mvn -DskipTests clean install --file azure-javaee-iaas/pom.xml
       - name: Azure login
         uses: azure/login@v1
         with:

--- a/.github/workflows/twas-ndBuild.yml
+++ b/.github/workflows/twas-ndBuild.yml
@@ -82,7 +82,6 @@ jobs:
           server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
           server-username: MAVEN_USERNAME # env variable for username
           server-password: MAVEN_TOKEN # env variable for token
-
       - name: Set Maven env
         env:
           MAVEN_USERNAME: github
@@ -91,13 +90,11 @@ jobs:
         run: |
           echo "MAVEN_USERNAME=${MAVEN_USERNAME}" >> "$GITHUB_ENV"
           echo "MAVEN_TOKEN=${MAVEN_TOKEN}" >> "$GITHUB_ENV"
-
       - name: Download arm-ttk used in partner center pipeline
         shell: bash
         run: |
           wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
           unzip arm-template-toolkit.zip -d arm-ttk
-
       - name: Checkout ${{ env.repoName }}
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/twas-ndBuild.yml
+++ b/.github/workflows/twas-ndBuild.yml
@@ -64,7 +64,6 @@ jobs:
         run: |
           curl -Lo external-deps-versions.properties https://raw.githubusercontent.com/Azure/azure-javaee-iaas/main/external-deps-versions.properties
           source external-deps-versions.properties
-          echo "refArmttk=${ARM_TTK_REFERENCE}" >> $GITHUB_ENV
           echo "azCliVersion=${AZ_CLI_VERSION}" >> $GITHUB_ENV
       - name: Setup environment variables
         id: setup-env-variables-based-on-dispatch-event
@@ -96,7 +95,6 @@ jobs:
         with:
           repository: Azure/arm-ttk
           path: arm-ttk
-          ref: ${{ env.refArmttk }}
       - name: Checkout ${{ env.repoName }}
         uses: actions/checkout@v3
         with:

--- a/ihs/README.md
+++ b/ihs/README.md
@@ -26,10 +26,18 @@ Please follow these steps:
    - Click Generate token and make sure to copy the token.
 
 2. Configure Maven Settings
-   - Locate or create the settings.xml file in your .m2 directory.
+   - Locate or create the settings.xml file in your .m2 directory(~/.m2/settings.xml).
    - Add the GitHub Package Registry server configuration with your username and the PAT you just created. It should look something like this:
       ```xml
-       <settings>
+       <settings xmlns="http://maven.apache.org/SETTINGS/1.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 
+                              https://maven.apache.org/xsd/settings-1.2.0.xsd">
+        
+      <!-- other settings
+      ...
+      -->
+     
         <servers>
           <server>
             <id>github</id>
@@ -37,6 +45,11 @@ Please follow these steps:
             <password>YOUR_PERSONAL_ACCESS_TOKEN</password>
           </server>
         </servers>
+     
+      <!-- other settings
+      ...
+      -->
+     
        </settings>
       ```
 

--- a/ihs/README.md
+++ b/ihs/README.md
@@ -12,6 +12,34 @@
 1. Install [Maven](https://maven.apache.org/download.cgi).
 1. Install [`jq`](https://stedolan.github.io/jq/download/).
 
+## Local Build Setup and Requirements
+This project utilizes [GitHub Packages](https://github.com/features/packages) for hosting and retrieving some dependencies. To ensure you can smoothly run and build the project in your local environment, specific configuration settings are required.
+
+GitHub Packages requires authentication to download or publish packages. Therefore, you need to configure your Maven `settings.xml` file to authenticate using your GitHub credentials. The primary reason for this is that GitHub Packages does not support anonymous access, even for public packages.
+
+Please follow these steps:
+
+1. Create a Personal Access Token (PAT)
+   - Go to [Personal access tokens](https://github.com/settings/tokens).
+   - Click on Generate new token.
+   - Give your token a descriptive name, set the expiration as needed, and select the scopes (read:packages, write:packages).
+   - Click Generate token and make sure to copy the token.
+
+2. Configure Maven Settings
+   - Locate or create the settings.xml file in your .m2 directory.
+   - Add the GitHub Package Registry server configuration with your username and the PAT you just created. It should look something like this:
+      ```xml
+       <settings>
+        <servers>
+          <server>
+            <id>github</id>
+            <username>YOUR_GITHUB_USERNAME</username>
+            <password>YOUR_PERSONAL_ACCESS_TOKEN</password>
+          </server>
+        </servers>
+       </settings>
+      ```
+
 ## Steps of deployment
 
 1. Checkout [azure-javaee-iaas](https://github.com/Azure/azure-javaee-iaas)

--- a/ihs/pom.xml
+++ b/ihs/pom.xml
@@ -22,20 +22,19 @@
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.websphere-ihs.image</artifactId>
     <version>1.0.11</version>
-    
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>
         <artifactId>azure-javaee-iaas-parent</artifactId>
-        <version>1.0.19</version>
+        <version>1.0.22</version>
         <relativePath></relativePath>
     </parent>
-    
+
     <packaging>jar</packaging>
     <name>${project.artifactId}</name>
 
     <properties>
         <git.repo>WASdev</git.repo>
-        <!-- 
+        <!--
             The default value for `git.tag` is defined in parent pom "azure-javaee-iaas-parent", which is `main`.
             It can also be overridden with `-Dgit.tag` at the maven command line if you use a different git branch.
             See https://github.com/Azure/azure-javaee-iaas/blob/main/arm-parent/pom.xml#L22-L24 for more available properties.
@@ -43,4 +42,20 @@
         <artifactsLocationBase>https://raw.githubusercontent.com/${git.repo}/azure.websphere-traditional.image/${git.tag}</artifactsLocationBase>
         <template.pid.properties.url>${artifactsLocationBase}/config.properties</template.pid.properties.url>
     </properties>
+
+    <repositories>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/azure-javaee/azure-javaee-iaas</url>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/azure-javaee/azure-javaee-iaas</url>
+        </pluginRepository>
+    </pluginRepositories>
 </project>

--- a/twas-base/README.md
+++ b/twas-base/README.md
@@ -26,10 +26,18 @@ Please follow these steps:
    - Click Generate token and make sure to copy the token.
 
 2. Configure Maven Settings
-   - Locate or create the settings.xml file in your .m2 directory.
+   - Locate or create the settings.xml file in your .m2 directory(~/.m2/settings.xml).
    - Add the GitHub Package Registry server configuration with your username and the PAT you just created. It should look something like this:
       ```xml
-       <settings>
+       <settings xmlns="http://maven.apache.org/SETTINGS/1.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 
+                              https://maven.apache.org/xsd/settings-1.2.0.xsd">
+        
+      <!-- other settings
+      ...
+      -->
+     
         <servers>
           <server>
             <id>github</id>
@@ -37,6 +45,11 @@ Please follow these steps:
             <password>YOUR_PERSONAL_ACCESS_TOKEN</password>
           </server>
         </servers>
+     
+      <!-- other settings
+      ...
+      -->
+     
        </settings>
       ```
      

--- a/twas-base/README.md
+++ b/twas-base/README.md
@@ -12,6 +12,34 @@
 1. Install [Maven](https://maven.apache.org/download.cgi).
 1. Install [`jq`](https://stedolan.github.io/jq/download/).
 
+## Local Build Setup and Requirements
+This project utilizes [GitHub Packages](https://github.com/features/packages) for hosting and retrieving some dependencies. To ensure you can smoothly run and build the project in your local environment, specific configuration settings are required.
+
+GitHub Packages requires authentication to download or publish packages. Therefore, you need to configure your Maven `settings.xml` file to authenticate using your GitHub credentials. The primary reason for this is that GitHub Packages does not support anonymous access, even for public packages.
+
+Please follow these steps:
+
+1. Create a Personal Access Token (PAT)
+   - Go to [Personal access tokens](https://github.com/settings/tokens).
+   - Click on Generate new token.
+   - Give your token a descriptive name, set the expiration as needed, and select the scopes (read:packages, write:packages).
+   - Click Generate token and make sure to copy the token.
+
+2. Configure Maven Settings
+   - Locate or create the settings.xml file in your .m2 directory.
+   - Add the GitHub Package Registry server configuration with your username and the PAT you just created. It should look something like this:
+      ```xml
+       <settings>
+        <servers>
+          <server>
+            <id>github</id>
+            <username>YOUR_GITHUB_USERNAME</username>
+            <password>YOUR_PERSONAL_ACCESS_TOKEN</password>
+          </server>
+        </servers>
+       </settings>
+      ```
+     
 ## Steps of deployment
 
 1. Checkout [azure-javaee-iaas](https://github.com/Azure/azure-javaee-iaas)

--- a/twas-base/pom.xml
+++ b/twas-base/pom.xml
@@ -22,20 +22,19 @@
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.websphere-base.image</artifactId>
     <version>1.0.10</version>
-    
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>
         <artifactId>azure-javaee-iaas-parent</artifactId>
-        <version>1.0.19</version>
+        <version>1.0.22</version>
         <relativePath></relativePath>
     </parent>
-    
+
     <packaging>jar</packaging>
     <name>${project.artifactId}</name>
 
     <properties>
         <git.repo>WASdev</git.repo>
-        <!-- 
+        <!--
             The default value for `git.tag` is defined in parent pom "azure-javaee-iaas-parent", which is `main`.
             It can also be overridden with `-Dgit.tag` at the maven command line if you use a different git branch.
             See https://github.com/Azure/azure-javaee-iaas/blob/main/arm-parent/pom.xml#L22-L24 for more available properties.
@@ -43,4 +42,20 @@
         <artifactsLocationBase>https://raw.githubusercontent.com/${git.repo}/azure.websphere-traditional.image/${git.tag}</artifactsLocationBase>
         <template.pid.properties.url>${artifactsLocationBase}/config.properties</template.pid.properties.url>
     </properties>
+
+    <repositories>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/azure-javaee/azure-javaee-iaas</url>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/azure-javaee/azure-javaee-iaas</url>
+        </pluginRepository>
+    </pluginRepositories>
 </project>

--- a/twas-nd/README.md
+++ b/twas-nd/README.md
@@ -26,10 +26,18 @@ Please follow these steps:
    - Click Generate token and make sure to copy the token.
 
 2. Configure Maven Settings
-   - Locate or create the settings.xml file in your .m2 directory.
+   - Locate or create the settings.xml file in your .m2 directory(~/.m2/settings.xml).
    - Add the GitHub Package Registry server configuration with your username and the PAT you just created. It should look something like this:
       ```xml
-       <settings>
+       <settings xmlns="http://maven.apache.org/SETTINGS/1.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 
+                              https://maven.apache.org/xsd/settings-1.2.0.xsd">
+        
+      <!-- other settings
+      ...
+      -->
+     
         <servers>
           <server>
             <id>github</id>
@@ -37,6 +45,11 @@ Please follow these steps:
             <password>YOUR_PERSONAL_ACCESS_TOKEN</password>
           </server>
         </servers>
+     
+      <!-- other settings
+      ...
+      -->
+     
        </settings>
       ```
      

--- a/twas-nd/README.md
+++ b/twas-nd/README.md
@@ -12,6 +12,34 @@
 1. Install [Maven](https://maven.apache.org/download.cgi).
 1. Install [`jq`](https://stedolan.github.io/jq/download/).
 
+## Local Build Setup and Requirements
+This project utilizes [GitHub Packages](https://github.com/features/packages) for hosting and retrieving some dependencies. To ensure you can smoothly run and build the project in your local environment, specific configuration settings are required.
+
+GitHub Packages requires authentication to download or publish packages. Therefore, you need to configure your Maven `settings.xml` file to authenticate using your GitHub credentials. The primary reason for this is that GitHub Packages does not support anonymous access, even for public packages.
+
+Please follow these steps:
+
+1. Create a Personal Access Token (PAT)
+   - Go to [Personal access tokens](https://github.com/settings/tokens).
+   - Click on Generate new token.
+   - Give your token a descriptive name, set the expiration as needed, and select the scopes (read:packages, write:packages).
+   - Click Generate token and make sure to copy the token.
+
+2. Configure Maven Settings
+   - Locate or create the settings.xml file in your .m2 directory.
+   - Add the GitHub Package Registry server configuration with your username and the PAT you just created. It should look something like this:
+      ```xml
+       <settings>
+        <servers>
+          <server>
+            <id>github</id>
+            <username>YOUR_GITHUB_USERNAME</username>
+            <password>YOUR_PERSONAL_ACCESS_TOKEN</password>
+          </server>
+        </servers>
+       </settings>
+      ```
+     
 ## Steps of deployment
 
 1. Checkout [azure-javaee-iaas](https://github.com/Azure/azure-javaee-iaas)

--- a/twas-nd/pom.xml
+++ b/twas-nd/pom.xml
@@ -22,20 +22,19 @@
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.websphere-traditional.image</artifactId>
     <version>1.0.13</version>
-    
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>
         <artifactId>azure-javaee-iaas-parent</artifactId>
-        <version>1.0.19</version>
+        <version>1.0.22</version>
         <relativePath></relativePath>
     </parent>
-    
+
     <packaging>jar</packaging>
     <name>${project.artifactId}</name>
 
     <properties>
         <git.repo>WASdev</git.repo>
-        <!-- 
+        <!--
             The default value for `git.tag` is defined in parent pom "azure-javaee-iaas-parent", which is `main`.
             It can also be overridden with `-Dgit.tag` at the maven command line if you use a different git branch.
             See https://github.com/Azure/azure-javaee-iaas/blob/main/arm-parent/pom.xml#L22-L24 for more available properties.
@@ -43,4 +42,20 @@
         <artifactsLocationBase>https://raw.githubusercontent.com/${git.repo}/azure.websphere-traditional.image/${git.tag}</artifactsLocationBase>
         <template.pid.properties.url>${artifactsLocationBase}/config.properties</template.pid.properties.url>
     </properties>
+
+    <repositories>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/azure-javaee/azure-javaee-iaas</url>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/azure-javaee/azure-javaee-iaas</url>
+        </pluginRepository>
+    </pluginRepositories>
 </project>


### PR DESCRIPTION
This pull request includes changes to the GitHub workflows and Maven configuration for the `ihs`, `twas-base`, and `twas-nd` projects, with the aim of simplifying the build process and improving the handling of dependencies. The most important changes are the removal of certain environment variables and checkout steps from the workflows, the addition of a new condition for deleting the `testResourceGroup`, and the addition of instructions for setting up local builds and repositories in the Maven configuration.

Changes to GitHub workflows:

* `.github/workflows/ihsBuild.yml`, `.github/workflows/twas-baseBuild.yml`, `.github/workflows/twas-ndBuild.yml`: 
    * Removed the `refArmttk` and `refJavaee` environment variables and the steps to checkout `azure-javaee-iaas` and `arm-ttk`. 
    * Instead, added steps to set Maven environment variables and download `arm-ttk` from a specific URL. Also, updated the condition for deleting the `testResourceGroup` to also check if the `imageVersionNumber` output from the `build` job is empty. 

Changes to Maven configuration:

* `ihs/README.md`, `twas-base/README.md`, `twas-nd/README.md`: Added instructions for setting up local builds with GitHub Packages, including creating a Personal Access Token (PAT) and configuring the Maven `settings.xml` file. 
* `ihs/pom.xml`, `twas-base/pom.xml`, `twas-nd/pom.xml`: Updated version and added GitHub Packages as a repository and plugin repository. 