### PR TITLE
Fix vm image certification failures

### DIFF
--- a/config.properties
+++ b/config.properties
@@ -14,7 +14,7 @@
 
 image.publisher=RedHat
 image.offer=RHEL
-image.sku=9-lvm
+image.sku=9_4
 image.version=latest
 
 datadisk.sizeGB=25


### PR DESCRIPTION
## Description

The certification failure report asks to apply [Red Hat security advisory RHSA-2024:2394](https://access.redhat.com/errata/RHSA-2024:2394), which is issued on `2024-04-30` and impacts Red Hat Enterprise Linux for x86_64 9 as well. For tWAS related vm image, it uses RHEL 9 as the base image, so we should update to a version of RHEL 9 vm image which includes the patch.

## Solution

The PR is to update RHEL image to `9_4`, which seems updated on `2024-05-06` and should include the required patch `RHSA-2024:2394`:

|Architecture|    Offer|                     Publisher|      Sku|                              Urn        |                                                                Version| |
|--------------|------------------------|--------------|-------------------------------|--------------------------------------------------------------------------|-----------------|-|
|x64       |      RHEL     |                 RedHat      |    9-lvm       |          RedHat:RHEL:9-lvm:9.3.2023110915            |                           9.3.2023110915|Updated on `20231109`, security patch is not released|
|x64|             RHEL          |            RedHat    |      9_4      |               RedHat:RHEL:9_4:9.3.2024050617            |                             9.3.2024050617|Updated on `20240506`, security patch is released|

You can run `az vm image list --publisher RedHat --offer RHEL --all --output table` to find out the two vm images mentioned above.

## Testing

3 pipelines ran successfully:
* [twas-base CICD](https://github.com/majguo/azure.websphere-traditional.image/actions/runs/9736807373)
* [twas-nd CICD](https://github.com/majguo/azure.websphere-traditional.image/actions/runs/9738421084)
* [ihs CICD](https://github.com/majguo/azure.websphere-traditional.image/actions/runs/9739287141)

Created a VM with vm image from Azure portal with the same RHEL vm image proposed by the PR:

```
"imageReference": {
    "publisher": "RedHat",
    "offer": "RHEL",
    "sku": "9_4",
    "version": "latest"
}
```
![image](https://github.com/WASdev/azure.websphere-traditional.image/assets/10357495/95e26834-e287-43d6-ba4f-7996442e677f)

Once the VM is created, ssh into the VM and run the following commands to verify if the security patch is included by searching the top 3 CVE fixed by the patch from RPM changelog:

```
rpm -q --changelog kernel | grep "CVE-2020-26555\|CVE-2022-0480\|CVE-2022-38096"
```

Output:
```
- drm/vmwgfx: Fix possible null pointer derefence with invalid contexts (Jocelyn Falempe) [RHEL-3181 RHEL-3191] {CVE-2022-38096}
- Reapply "memcg: enable accounting for file lock caches" (Wander Lairson Costa) [RHEL-8487 RHEL-9039] {CVE-2022-0480}
- Bluetooth: avoid memcmp() out of bounds warning (David Marlin) [RHEL-18222] {CVE-2020-26555}
- Bluetooth: hci_event: Fix coding style (David Marlin) [RHEL-18222] {CVE-2020-26555}
- Bluetooth: hci_event: Fix using memcmp when comparing keys (David Marlin) [RHEL-18222] {CVE-2020-26555}
- Bluetooth: Reject connection with the device which has same BD_ADDR (David Marlin) [RHEL-18222] {CVE-2020-26555}
- Bluetooth: hci_event: Ignore NULL link key (David Marlin) [RHEL-18222] {CVE-2020-26555}
```

It demonstrates that the latest `RedHat:RHEL:9_4` vm image most likely include the required patch.

Of course, whether the issue is fixed or not can only be finally verified by publishing vm image at partner center again.

## Dependency

Another PR which is not related but required for tWAS cluster repo (otherwise the image pipeline will fail when it invokes integration test pipeline in tWAS cluster repo):
* https://github.com/WASdev/azure.websphere-traditional.cluster/pull/253

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>