### PR TITLE
Update to actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -165,12 +165,12 @@ jobs:
           timeout 1m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${publicIP} 22
           sshpass -p ${vmAdminPassword} scp ${vmAdminId}@${publicIP}:/home/${vmAdminId}/scan_report_* .
       - name: Upload openscap scanning report before remidation
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: scan-report-before
           path: scan_report_before.html
       - name: Upload openscap scanning report after remidation
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: scan-report-after
           path: scan_report_after.html
@@ -316,7 +316,7 @@ jobs:
           echo "##[set-output name=osDiskSasUrl;]${osDiskSasUrl}"
           echo "##[set-output name=dataDiskSasUrl;]${dataDiskSasUrl}"
       - name: Upload SAS url
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sasurl-ihs
           path: sas-url-ihs.txt

--- a/.github/workflows/twas-baseBuild.yml
+++ b/.github/workflows/twas-baseBuild.yml
@@ -155,12 +155,12 @@ jobs:
           timeout 1m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${publicIP} 22
           sshpass -p ${vmAdminPassword} scp ${vmAdminId}@${publicIP}:/home/${vmAdminId}/scan_report_* .
       - name: Upload openscap scanning report before remidation
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: scan-report-before
           path: scan_report_before.html
       - name: Upload openscap scanning report after remidation
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: scan-report-after
           path: scan_report_after.html
@@ -304,7 +304,7 @@ jobs:
           echo "##[set-output name=osDiskSasUrl;]${osDiskSasUrl}"
           echo "##[set-output name=dataDiskSasUrl;]${dataDiskSasUrl}"
       - name: Upload SAS url
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sasurl-twasbase
           path: sas-url-twasbase.txt

--- a/.github/workflows/twas-ndBuild.yml
+++ b/.github/workflows/twas-ndBuild.yml
@@ -155,12 +155,12 @@ jobs:
           timeout 1m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${publicIP} 22
           sshpass -p ${vmAdminPassword} scp ${vmAdminId}@${publicIP}:/home/${vmAdminId}/scan_report_* .
       - name: Upload openscap scanning report before remidation
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: scan-report-before
           path: scan_report_before.html
       - name: Upload openscap scanning report after remidation
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: scan-report-after
           path: scan_report_after.html
@@ -305,7 +305,7 @@ jobs:
           echo "##[set-output name=osDiskSasUrl;]${osDiskSasUrl}"
           echo "##[set-output name=dataDiskSasUrl;]${dataDiskSasUrl}"
       - name: Upload SAS url
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sasurl-twasnd
           path: sas-url-twasnd.txt


### PR DESCRIPTION
The PR is to fix the issue detected in https://github.com/WASdev/azure.websphere-traditional.singleserver/actions/runs/10824397307/job/30031567803:
![image](https://github.com/user-attachments/assets/d408e279-1bcc-4d16-9a50-62eccf5c2cdf)

Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/.

## Dependent PRs

* https://github.com/WASdev/azure.websphere-traditional.singleserver/pull/107
* https://github.com/WASdev/azure.websphere-traditional.cluster/pull/256

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>