### PR TITLE
Update to version of `microsoft/microsoft-partner-center-github-action` to `v3.2`

### DIFF
--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -321,7 +321,7 @@ jobs:
           name: sasurl-ihs
           path: sas-url-ihs.txt
       - name: Update offer sas url and version
-        uses: microsoft/microsoft-partner-center-github-action@v3.1
+        uses: microsoft/microsoft-partner-center-github-action@v3.2
         if: ${{ inputs.updateOfferArtifact == true && needs.build.outputs.imageVersionNumber != '' }}
         with:
           offerId: ${{ env.offerId }}

--- a/.github/workflows/twas-baseBuild.yml
+++ b/.github/workflows/twas-baseBuild.yml
@@ -309,7 +309,7 @@ jobs:
           name: sasurl-twasbase
           path: sas-url-twasbase.txt
       - name: Update offer sas url and version
-        uses: microsoft/microsoft-partner-center-github-action@v3.1
+        uses: microsoft/microsoft-partner-center-github-action@v3.2
         if: ${{ needs.build.outputs.imageVersionNumber != '' }}
         with:
           offerId: ${{ env.offerId }}

--- a/.github/workflows/twas-ndBuild.yml
+++ b/.github/workflows/twas-ndBuild.yml
@@ -310,7 +310,7 @@ jobs:
           name: sasurl-twasnd
           path: sas-url-twasnd.txt
       - name: Update offer sas url and version
-        uses: microsoft/microsoft-partner-center-github-action@v3.1
+        uses: microsoft/microsoft-partner-center-github-action@v3.2
         if: ${{ needs.build.outputs.imageVersionNumber != '' }}
         with:
           offerId: ${{ env.offerId }}

--- a/.github/workflows/update-vm-offer.yml
+++ b/.github/workflows/update-vm-offer.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - name: Update offer artifact
         id: update-offer-artifact
-        uses: microsoft/microsoft-partner-center-github-action@v3.1
+        uses: microsoft/microsoft-partner-center-github-action@v3.2
         with:
           offerId: ${{ env.offerId }}
           planId: ${{ env.planId }}


### PR DESCRIPTION
Reference to new released version [v3.2](https://github.com/microsoft/microsoft-partner-center-github-action/releases/tag/v3.2) for `microsoft/microsoft-partner-center-github-action` which fixed the issue that VM offer failed to be updated in partner center due to the incorrect domain name for schema uri of Product Ingestion API.

Test: https://github.com/azure-javaee/azure.websphere-traditional.image/actions/runs/13213374955
* **NOTE**: it's just for testing purpose, the new version added by the test has already been manually deleted after the test verification is done.

 Signed-off-by: Jianguo Ma <jiangma@microsoft.com>