### PR TITLE
Update twas-nd installation repository url

### DIFF
--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -226,7 +226,7 @@ jobs:
         run: |
           # Trigger the workflow run
           requestData={\"ref\":\"${GITHUB_REF_NAME}\",\"inputs\":{\"databaseType\":\"none\",\"ndImageResourceId\":\"${ndImageResourceId}\",\"ihsImageResourceId\":\"${ihsImageResourceId}\"}}
-          curl --verbose -L -X POST \
+          curl --fail --verbose -L -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${accessToken}"\
             -H "X-GitHub-Api-Version: 2022-11-28" \

--- a/.github/workflows/twas-baseBuild.yml
+++ b/.github/workflows/twas-baseBuild.yml
@@ -214,7 +214,7 @@ jobs:
         run: |
           # Trigger the workflow run
           requestData={\"ref\":\"${GITHUB_REF_NAME}\",\"inputs\":{\"databaseType\":\"none\",\"imageResourceId\":\"${imageResourceId}\"}}
-          curl --verbose -L -X POST \
+          curl --fail --verbose -L -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${accessToken}"\
             -H "X-GitHub-Api-Version: 2022-11-28" \

--- a/.github/workflows/twas-ndBuild.yml
+++ b/.github/workflows/twas-ndBuild.yml
@@ -215,7 +215,7 @@ jobs:
         run: |
           # Trigger the workflow run
           requestData={\"ref\":\"${GITHUB_REF_NAME}\",\"inputs\":{\"databaseType\":\"none\",\"ndImageResourceId\":\"${ndImageResourceId}\",\"ihsImageResourceId\":\"${ihsImageResourceId}\"}}
-          curl --verbose -L -X POST \
+          curl --fail --verbose -L -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${accessToken}"\
             -H "X-GitHub-Api-Version: 2022-11-28" \

--- a/twas-nd/src/main/scripts/virtualimage.properties
+++ b/twas-nd/src/main/scripts/virtualimage.properties
@@ -13,7 +13,7 @@
 #  limitations under the License.
 WAS_ND_TRADITIONAL=com.ibm.websphere.ND.v90
 IBM_JAVA_SDK=com.ibm.java.jdk.v8
-REPOSITORY_URL=https://www.ibm.com/software/repositorymanager/entitled
+REPOSITORY_URL=http://www.ibm.com/software/repositorymanager/V9WASND
 WAS_ND_VERSION_ENTITLED=ND.v90_9.0.5007
 NO_PACKAGES_FOUND="No packages were found"
 IM_INSTALL_KIT=agent.installer.linux.gtk.x86_64.zip


### PR DESCRIPTION
## Description

The PR applies the similar workaround from #61, which update the repository url of twas-nd from `https://www.ibm.com/software/repositorymanager/entitled` to `http://www.ibm.com/software/repositorymanager/V9WASND`, in order to address the issue captured in [twas-nd CICD · azure-javaee/azure.websphere-traditional.image@2f96c87](https://github.com/azure-javaee/azure.websphere-traditional.image/actions/runs/13233476612/job/36934300089).

The additional enhancement is to use `--fail` option in curl command so that it fails fast if the singleserver/cluster integration test fails to be triggered with http errors.

## Test 

Workflow run succeeded: https://github.com/majguo/azure.websphere-traditional.image/actions/runs/13241864914

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>