### PR TITLE
CICD pipeline enhancements

### DIFF
--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -225,7 +225,7 @@ jobs:
         if: ${{ !inputs.skipIntegrationTests }}
         run: |
           # Trigger the workflow run
-          requestData={\"ref\":\"${GITHUB_REF_NAME}\",\"inputs\":{\"databaseType\":\"none\",\"ndImageResourceId\":\"${ndImageResourceId}\",\"ihsImageResourceId\":\"${ihsImageResourceId}\"}}
+          requestData={\"ref\":\"${GITHUB_REF_NAME}\",\"inputs\":{\"databaseType\":\"none\",\"ndImageResourceId\":\"${ndImageResourceId}\",\"ihsImageResourceId\":\"${ihsImageResourceId}\",\"location\":\"${{ env.location }}\"}}
           curl --fail --verbose -L -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${accessToken}"\

--- a/.github/workflows/twas-baseBuild.yml
+++ b/.github/workflows/twas-baseBuild.yml
@@ -213,7 +213,7 @@ jobs:
       - name: Verify the image with twas-single integration-test pipeline
         run: |
           # Trigger the workflow run
-          requestData={\"ref\":\"${GITHUB_REF_NAME}\",\"inputs\":{\"databaseType\":\"none\",\"imageResourceId\":\"${imageResourceId}\"}}
+          requestData={\"ref\":\"${GITHUB_REF_NAME}\",\"inputs\":{\"databaseType\":\"none\",\"imageResourceId\":\"${imageResourceId}\",\"location\":\"${{ env.location }}\"}}
           curl --fail --verbose -L -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${accessToken}"\

--- a/.github/workflows/twas-ndBuild.yml
+++ b/.github/workflows/twas-ndBuild.yml
@@ -214,7 +214,7 @@ jobs:
       - name: Verify the image with twas-cluster integration-test pipeline
         run: |
           # Trigger the workflow run
-          requestData={\"ref\":\"${GITHUB_REF_NAME}\",\"inputs\":{\"databaseType\":\"none\",\"ndImageResourceId\":\"${ndImageResourceId}\",\"ihsImageResourceId\":\"${ihsImageResourceId}\"}}
+          requestData={\"ref\":\"${GITHUB_REF_NAME}\",\"inputs\":{\"databaseType\":\"none\",\"ndImageResourceId\":\"${ndImageResourceId}\",\"ihsImageResourceId\":\"${ihsImageResourceId}\",\"location\":\"${{ env.location }}\"}}
           curl --fail --verbose -L -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${accessToken}"\


### PR DESCRIPTION
This pull request includes updates to several GitHub Actions workflow files to add a new `location` parameter in the request data. 

Changes to GitHub Actions workflows:

* [`.github/workflows/ihsBuild.yml`](diffhunk://#diff-d3b6f66387b4f43de178e32bab5b0dcc786385e24a847110f40484d4e3a3f121L228-R228): Added the `location` parameter to the `requestData` in the integration tests trigger.
* [`.github/workflows/twas-baseBuild.yml`](diffhunk://#diff-bfa8815a785fb158eebfabeae46b703fd9f6b292d12cbb672e6dbe85a4fdd0f4L216-R216): Added the `location` parameter to the `requestData` in the image verification step.
* [`.github/workflows/twas-ndBuild.yml`](diffhunk://#diff-7cbf9c51c350c81d48c4dc8cf71f2deb121795bedf1fb700e2d03e7a62b3f95eL217-R217): Added the `location` parameter to the `requestData` in the integration tests trigger.

### Testing

The VM base image CICD integration-test pipeline passed:
* [twas-base CICD #80](https://github.com/majguo/azure.websphere-traditional.image/actions/runs/13672202142)
* [ihs CICD #54](https://github.com/majguo/azure.websphere-traditional.image/actions/runs/13671713180)
* [twas-nd CICD #51](https://github.com/majguo/azure.websphere-traditional.image/actions/runs/13670995373)

### Dependent PRs

This PR should be merged together the following dependent PRs that add a new input parameter `location`:
* https://github.com/WASdev/azure.websphere-traditional.cluster/pull/262
* https://github.com/WASdev/azure.websphere-traditional.singleserver/pull/110