### PR TITLE
Fix issue `/datadrive/virtualimage.properties: No such file or directory`

### DIFF
--- a/ihs/src/main/scripts/was-check.sh
+++ b/ihs/src/main/scripts/was-check.sh
@@ -56,7 +56,7 @@ if [ ${#ibmIdCredentials[@]} -eq 2 ]; then
         echo "$output" >> $WAS_LOG_PATH
         output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl uninstall "$WEBSPHERE_WCT" "$IBM_JAVA_SDK" -installationDirectory ${WCT_INSTALL_DIRECTORY})
         echo "$output" >> $WAS_LOG_PATH
-        rm -rf /datadrive/IBM && rm -rf /datadrive/virtualimage.properties
+        rm -rf /datadrive/IBM
     fi
     echo "$(date): WebSphere installation updated." >> $WAS_LOG_PATH
 else

--- a/twas-base/src/main/scripts/was-check.sh
+++ b/twas-base/src/main/scripts/was-check.sh
@@ -52,7 +52,7 @@ if [ ${#ibmIdCredentials[@]} -eq 2 ]; then
         # Remove tWAS installation for the un-entitled or undefined user
         output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl uninstall "$WAS_BASE_TRADITIONAL" "$IBM_JAVA_SDK" -installationDirectory ${WAS_BASE_INSTALL_DIRECTORY})
         echo "$output" >> $WAS_LOG_PATH
-        rm -rf /datadrive/IBM && rm -rf /datadrive/virtualimage.properties
+        rm -rf /datadrive/IBM
     fi
     echo "$(date): WebSphere installation updated." >> $WAS_LOG_PATH
 else

--- a/twas-nd/src/main/scripts/was-check.sh
+++ b/twas-nd/src/main/scripts/was-check.sh
@@ -52,7 +52,7 @@ if [ ${#ibmIdCredentials[@]} -eq 2 ]; then
         # Remove tWAS installation for the un-entitled or undefined user
         output=$(${IM_INSTALL_DIRECTORY}/eclipse/tools/imcl uninstall "$WAS_ND_TRADITIONAL" "$IBM_JAVA_SDK" -installationDirectory ${WAS_ND_INSTALL_DIRECTORY})
         echo "$output" >> $WAS_LOG_PATH
-        rm -rf /datadrive/IBM && rm -rf /datadrive/virtualimage.properties
+        rm -rf /datadrive/IBM
     fi
     echo "$(date): WebSphere installation updated." >> $WAS_LOG_PATH
 else


### PR DESCRIPTION
This pull request includes changes to several scripts related to WebSphere installation checks. The main change involves removing the deletion of the `virtualimage.properties` file. The reason behind is that `/datadrive/virtualimage.properties` shouldn't be removed in cloud-init as it's accessed by vm extension asynchronously. This corner case is captured by [twas-base CICD #70](https://github.com/WASdev/azure.websphere-traditional.image/actions/runs/13791848447/job/38576113611).

Changes to WebSphere installation scripts:

* [`ihs/src/main/scripts/was-check.sh`](diffhunk://#diff-15ff380841704bac45665515b268c84afcd3e30b4975c62c3d27371ff2913dd2L59-R59): Removed the deletion of the `virtualimage.properties` file during the WebSphere uninstall process.
* [`twas-base/src/main/scripts/was-check.sh`](diffhunk://#diff-d11d39f62e9843581a5cdb96811c0361a12a62b4253f28ef5fce0fa5d88b3781L55-R55): Removed the deletion of the `virtualimage.properties` file during the WebSphere uninstall process.
* [`twas-nd/src/main/scripts/was-check.sh`](diffhunk://#diff-56820659516b6acaca712409f898de9184f60e2b16348e95c5d4f1b68d8e9bc7L55-R55): Removed the deletion of the `virtualimage.properties` file during the WebSphere uninstall process.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>