### PR TITLE
Upgrade REHL of vm base image to `9_5` to fix `CVE-2025-27363`

### DIFF
--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -20,6 +20,11 @@ on:
         required: true
         type: boolean
         default: false
+      retainTestingVMs:
+        description: 'If true, retain testing VMs that are created with the image.'
+        required: true
+        type: boolean
+        default: false
   # Allows you to run this workflow using GitHub APIs
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
   # REPO_NAME=WASdev/azure.websphere-traditional.image
@@ -219,7 +224,10 @@ jobs:
                 imageResourceId=$imageResourceId vmAdminId=${{ env.vmAdminId }} vmAdminPwd=${{ env.vmAdminPassword }} \
                 scriptLocation=${{ env.scriptLocation }}
 
-            az group delete -n $rgName --yes --no-wait
+            # Remove VM if inputs.retainTestingVMs is false
+            if [ ${{ inputs.retainTestingVMs }} == 'false' ]; then
+              az group delete -n $rgName --yes --no-wait
+            fi
           done
       - name: Verify the image with twas-cluster integration-test pipeline
         if: ${{ !inputs.skipIntegrationTests }}
@@ -372,6 +380,7 @@ jobs:
           creds: ${{ env.azureCredentials }}
       - name: Delete resource groups during verification
         continue-on-error: true
+        if: ${{ !inputs.retainTestingVMs }}
         run: |
             vmGroups=( ${{ env.testResourceGroup }}-entitled ${{ env.testResourceGroup }}-unentitled ${{ env.testResourceGroup }}-evaluation )
             for (( i=0; i<${#vmGroups[@]}; i++ )); do 

--- a/.github/workflows/twas-baseBuild.yml
+++ b/.github/workflows/twas-baseBuild.yml
@@ -10,6 +10,21 @@ on:
       imageVersionNumber:
         description: 'Provide image version number'
         required: false
+      updateOfferArtifact:
+        description: 'Update offer artifact'
+        required: true
+        type: boolean
+        default: true
+      skipIntegrationTests:
+        description: 'If true, do not call integration tests in other repositories.'
+        required: true
+        type: boolean
+        default: false
+      retainTestingVMs:
+        description: 'If true, retain testing VMs that are created with the image.'
+        required: true
+        type: boolean
+        default: false
   # Allows you to run this workflow using GitHub APIs
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
   # REPO_NAME=WASdev/azure.websphere-traditional.image
@@ -208,9 +223,13 @@ jobs:
                 imageResourceId=$imageResourceId vmAdminId=${{ env.vmAdminId }} vmAdminPwd=${{ env.vmAdminPassword }} \
                 scriptLocation=${{ env.scriptLocation }}
 
-            az group delete -n $rgName --yes --no-wait
+            # Remove VM if inputs.retainTestingVMs is false
+            if [ ${{ inputs.retainTestingVMs }} == 'false' ]; then
+              az group delete -n $rgName --yes --no-wait
+            fi
           done
       - name: Verify the image with twas-single integration-test pipeline
+        if: ${{ !inputs.skipIntegrationTests }}
         run: |
           # Trigger the workflow run
           requestData={\"ref\":\"${GITHUB_REF_NAME}\",\"inputs\":{\"databaseType\":\"none\",\"imageResourceId\":\"${imageResourceId}\",\"location\":\"${{ env.location }}\"}}
@@ -324,7 +343,7 @@ jobs:
           path: sas-url-twasbase.txt
       - name: Update offer sas url and version
         uses: microsoft/microsoft-partner-center-github-action@v3.2
-        if: ${{ needs.build.outputs.imageVersionNumber != '' }}
+        if: ${{ inputs.updateOfferArtifact == true && needs.build.outputs.imageVersionNumber != '' }}
         with:
           offerId: ${{ env.offerId }}
           planId: ${{ env.planId }}
@@ -360,6 +379,7 @@ jobs:
           creds: ${{ env.azureCredentials }}
       - name: Delete resource groups during verification
         continue-on-error: true
+        if: ${{ !inputs.retainTestingVMs }}
         run: |
             vmGroups=( ${{ env.testResourceGroup }}-entitled ${{ env.testResourceGroup }}-unentitled ${{ env.testResourceGroup }}-evaluation )
             for (( i=0; i<${#vmGroups[@]}; i++ )); do 

--- a/.github/workflows/twas-ndBuild.yml
+++ b/.github/workflows/twas-ndBuild.yml
@@ -10,6 +10,21 @@ on:
       imageVersionNumber:
         description: 'Provide image version number'
         required: false
+      updateOfferArtifact:
+        description: 'Update offer artifact'
+        required: true
+        type: boolean
+        default: true
+      skipIntegrationTests:
+        description: 'If true, do not call integration tests in other repositories.'
+        required: true
+        type: boolean
+        default: false
+      retainTestingVMs:
+        description: 'If true, retain testing VMs that are created with the image.'
+        required: true
+        type: boolean
+        default: false
   # Allows you to run this workflow using GitHub APIs
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
   # REPO_NAME=WASdev/azure.websphere-traditional.image
@@ -209,9 +224,13 @@ jobs:
                 imageResourceId=$imageResourceId vmAdminId=${{ env.vmAdminId }} vmAdminPwd=${{ env.vmAdminPassword }} \
                 scriptLocation=${{ env.scriptLocation }}
 
-            az group delete -n $rgName --yes --no-wait
+            # Remove VM if inputs.retainTestingVMs is false
+            if [ ${{ inputs.retainTestingVMs }} == 'false' ]; then
+              az group delete -n $rgName --yes --no-wait
+            fi
           done
       - name: Verify the image with twas-cluster integration-test pipeline
+        if: ${{ !inputs.skipIntegrationTests }}
         run: |
           # Trigger the workflow run
           requestData={\"ref\":\"${GITHUB_REF_NAME}\",\"inputs\":{\"databaseType\":\"none\",\"ndImageResourceId\":\"${ndImageResourceId}\",\"ihsImageResourceId\":\"${ihsImageResourceId}\",\"location\":\"${{ env.location }}\"}}
@@ -325,7 +344,7 @@ jobs:
           path: sas-url-twasnd.txt
       - name: Update offer sas url and version
         uses: microsoft/microsoft-partner-center-github-action@v3.2
-        if: ${{ needs.build.outputs.imageVersionNumber != '' }}
+        if: ${{ inputs.updateOfferArtifact == true && needs.build.outputs.imageVersionNumber != '' }}
         with:
           offerId: ${{ env.offerId }}
           planId: ${{ env.planId }}
@@ -361,6 +380,7 @@ jobs:
           creds: ${{ env.azureCredentials }}
       - name: Delete resource groups during verification
         continue-on-error: true
+        if: ${{ !inputs.retainTestingVMs }}
         run: |
             vmGroups=( ${{ env.testResourceGroup }}-entitled ${{ env.testResourceGroup }}-unentitled ${{ env.testResourceGroup }}-evaluation )
             for (( i=0; i<${#vmGroups[@]}; i++ )); do 

--- a/config.properties
+++ b/config.properties
@@ -14,7 +14,7 @@
 
 image.publisher=RedHat
 image.offer=RHEL
-image.sku=9_4
+image.sku=9_5
 image.version=latest
 
 datadisk.sizeGB=25


### PR DESCRIPTION
Per @venunathb's testing and [RHSA-2025:3407](https://access.redhat.com/errata/RHSA-2025:3407), the `freetype` library installed in the current VM image has no patch for `CVE-2025-2736`:
```
yum list installed | grep freetype
freetype.x86_64                               2.10.4-9.el9                  @anaconda
```

This pull targets to fix `CVE-2025-2736` by upgrading REHL of vm base image to `9_5`. Additionally, it also includes changes to the GitHub Actions workflows by adding new input parameters to control the retention of testing VMs and updating offer artifacts, as well as conditional logic to handle these new inputs.

Update to configuration:

* [`config.properties`](diffhunk://#diff-763a89c2f6334284dbcf4ae81f31fec29a9093ceb6628fe39a930f1aa0feb9d5L17-R17): Updated the `image.sku` from `9_4` to `9_5`.

Improvements to GitHub Actions workflows:

* [`.github/workflows/ihsBuild.yml`](diffhunk://#diff-d3b6f66387b4f43de178e32bab5b0dcc786385e24a847110f40484d4e3a3f121R23-R27): Added `retainTestingVMs` input parameter to control whether testing VMs are retained and added conditional logic to delete VMs based on this parameter. [[1]](diffhunk://#diff-d3b6f66387b4f43de178e32bab5b0dcc786385e24a847110f40484d4e3a3f121R23-R27) [[2]](diffhunk://#diff-d3b6f66387b4f43de178e32bab5b0dcc786385e24a847110f40484d4e3a3f121R227-R230) [[3]](diffhunk://#diff-d3b6f66387b4f43de178e32bab5b0dcc786385e24a847110f40484d4e3a3f121R383)
* [`.github/workflows/twas-baseBuild.yml`](diffhunk://#diff-bfa8815a785fb158eebfabeae46b703fd9f6b292d12cbb672e6dbe85a4fdd0f4R13-R27): Added `updateOfferArtifact`, `skipIntegrationTests`, and `retainTestingVMs` input parameters. Updated conditional logic to handle these parameters for deleting VMs and updating offer artifacts. [[1]](diffhunk://#diff-bfa8815a785fb158eebfabeae46b703fd9f6b292d12cbb672e6dbe85a4fdd0f4R13-R27) [[2]](diffhunk://#diff-bfa8815a785fb158eebfabeae46b703fd9f6b292d12cbb672e6dbe85a4fdd0f4R226-R232) [[3]](diffhunk://#diff-bfa8815a785fb158eebfabeae46b703fd9f6b292d12cbb672e6dbe85a4fdd0f4L327-R346) [[4]](diffhunk://#diff-bfa8815a785fb158eebfabeae46b703fd9f6b292d12cbb672e6dbe85a4fdd0f4R382)
* [`.github/workflows/twas-ndBuild.yml`](diffhunk://#diff-7cbf9c51c350c81d48c4dc8cf71f2deb121795bedf1fb700e2d03e7a62b3f95eR13-R27): Added `updateOfferArtifact`, `skipIntegrationTests`, and `retainTestingVMs` input parameters. Updated conditional logic to handle these parameters for deleting VMs and updating offer artifacts. [[1]](diffhunk://#diff-7cbf9c51c350c81d48c4dc8cf71f2deb121795bedf1fb700e2d03e7a62b3f95eR13-R27) [[2]](diffhunk://#diff-7cbf9c51c350c81d48c4dc8cf71f2deb121795bedf1fb700e2d03e7a62b3f95eR227-R233) [[3]](diffhunk://#diff-7cbf9c51c350c81d48c4dc8cf71f2deb121795bedf1fb700e2d03e7a62b3f95eL328-R347) [[4]](diffhunk://#diff-7cbf9c51c350c81d48c4dc8cf71f2deb121795bedf1fb700e2d03e7a62b3f95eR383)

## Testing

Verified that the installed `freetype` library in RHEL `9_5` is updated to `2.10.4-10.el9_5` (listed in [RHSA-2025:3407](https://access.redhat.com/errata/RHSA-2025:3407)), which includes the patch for `CVE-2025-2736`.

```
yum list installed | grep freetype
freetype.x86_64                               2.10.4-10.el9_5               @rhel-9-for-x86_64-baseos-rhui-rpms
```

Verified that VM image pipelines ran successfully:
* [ihs CICD #56:](https://github.com/majguo/azure.websphere-traditional.image/actions/runs/14448591536)
* [twas-nd CICD #53](https://github.com/majguo/azure.websphere-traditional.image/actions/runs/14447413101)
* [twas-base CICD #89](https://github.com/majguo/azure.websphere-traditional.image/actions/runs/14447409188)
