### PR TITLE
Fix the issue that fails to export html report for oscap

### DIFF
--- a/.github/workflows/ihsBuild.yml
+++ b/.github/workflows/ihsBuild.yml
@@ -393,8 +393,3 @@ jobs:
                  echo "Resource group $rgName does not exist."
                fi  
             done
-      - name: Delete testResourceGroup
-        if: ${{ needs.verify_the_image.result != 'success' || needs.build.outputs.imageVersionNumber == '' }}
-        run: |
-            echo "The verify_the_image result is ${{ needs.verify_the_image.result }}, delete the testResourceGroup."
-            az group delete -n ${{ env.testResourceGroup }} --yes --no-wait

--- a/.github/workflows/twas-baseBuild.yml
+++ b/.github/workflows/twas-baseBuild.yml
@@ -392,8 +392,3 @@ jobs:
                  echo "Resource group $rgName does not exist."
                fi  
             done
-      - name: Delete testResourceGroup
-        if: ${{ needs.verify_the_image.result != 'success' || needs.build.outputs.imageVersionNumber == '' }}
-        run: |
-            echo "The verify_the_image result is ${{ needs.verify_the_image.result }}, delete the testResourceGroup."
-            az group delete -n ${{ env.testResourceGroup }} --yes --no-wait

--- a/.github/workflows/twas-ndBuild.yml
+++ b/.github/workflows/twas-ndBuild.yml
@@ -393,8 +393,3 @@ jobs:
                  echo "Resource group $rgName does not exist."
                fi  
             done
-      - name: Delete testResourceGroup
-        if: ${{ needs.verify_the_image.result != 'success' || needs.build.outputs.imageVersionNumber == '' }}
-        run: |
-            echo "The verify_the_image result is ${{ needs.verify_the_image.result }}, delete the testResourceGroup."
-            az group delete -n ${{ env.testResourceGroup }} --yes --no-wait    

--- a/utilities/oscap.sh
+++ b/utilities/oscap.sh
@@ -24,8 +24,7 @@ yum install scap-security-guide -y -q
 
 # Peform a SCAP compliance scan 
 oscap xccdf eval --profile xccdf_org.ssgproject.content_profile_cis_workstation_l1 --fetch-remote-resources \
-    --results scan_results_before.xml --report scan_report_before.html \
-    /usr/share/xml/scap/ssg/content/ssg-rhel9-ds.xml
+    --results scan_results_before.xml /usr/share/xml/scap/ssg/content/ssg-rhel9-ds.xml
 
 # Peform a SCAP compliance remediation with two skipping rules which conflict with Azure Linux Agent (waagent)
 oscap xccdf eval --remediate --profile xccdf_org.ssgproject.content_profile_cis_workstation_l1 --fetch-remote-resources \
@@ -34,11 +33,20 @@ oscap xccdf eval --remediate --profile xccdf_org.ssgproject.content_profile_cis_
     /usr/share/xml/scap/ssg/content/ssg-rhel9-ds.xml
 # Peform a SCAP compliance scan agin after remediation
 oscap xccdf eval --profile xccdf_org.ssgproject.content_profile_cis_workstation_l1 --fetch-remote-resources \
-    --results scan_results_after.xml --report scan_report_after.html \
-    /usr/share/xml/scap/ssg/content/ssg-rhel9-ds.xml
+    --results scan_results_after.xml /usr/share/xml/scap/ssg/content/ssg-rhel9-ds.xml
+
+# Generate reports in HTML format by applying the workaround from:
+# https://forums.almalinux.org/t/oscap-xccdf-invocation-will-segfault-maybe-due-to-libxslt-patch/5790
+rpm -e --nodeps libxslt
+dnf install -y libxslt-1.1.34-9.el9_5.1
+oscap xccdf generate report scan_results_before.xml > scan_report_before.html
+oscap xccdf generate report scan_results_after.xml > scan_report_after.html
+
+# Copy the reports to the admin home directory
 cp scan_report_* /home/${admin}/
 
 # Remove openscap-scanner and security policies
+dnf remove -y libxslt-1.1.34-9.el9_5.1
 yum remove scap-security-guide -y -q
 yum remove openscap-scanner -y -q
 


### PR DESCRIPTION
This pull request includes the fix for SCAP scan reporting. It also updates workflow files by not  removing resource group for troubleshooting vm image generation issue. Below is a summary of the most important changes grouped by theme:

### SCAP Compliance Script Enhancements:
* Updated `oscap.sh` to remove the `--report` option from SCAP compliance scan commands to address a potential issue with report generation. Reports are now generated separately using the `oscap xccdf generate report` command. [[1]](diffhunk://#diff-42e04a5cb5612dd09b0e0a645a2838cf173d34f8f445f5d664fdfe0e39a4f183L27-R27) [[2]](diffhunk://#diff-42e04a5cb5612dd09b0e0a645a2838cf173d34f8f445f5d664fdfe0e39a4f183L37-R49)
* Added a workaround to resolve a known issue with `libxslt` causing segmentation faults during report generation. This includes uninstalling and reinstalling a specific version of `libxslt`.
* Ensured generated reports are copied to the admin's home directory and cleaned up by removing `libxslt` and other related packages after the process.

### Workflow Updates:
* Removed the step to delete `testResourceGroup` in `.github/workflows/ihsBuild.yml`, `.github/workflows/twas-baseBuild.yml`, and `.github/workflows/twas-ndBuild.yml`. This step was conditional on the `verify_the_image` result or the absence of an image version number, and its removal simplifies the workflows. [[1]](diffhunk://#diff-d3b6f66387b4f43de178e32bab5b0dcc786385e24a847110f40484d4e3a3f121L396-L400) [[2]](diffhunk://#diff-bfa8815a785fb158eebfabeae46b703fd9f6b292d12cbb672e6dbe85a4fdd0f4L395-L399) [[3]](diffhunk://#diff-7cbf9c51c350c81d48c4dc8cf71f2deb121795bedf1fb700e2d03e7a62b3f95eL396-L400)

## Testing

[twas-base CICD #93](https://github.com/majguo/azure.websphere-traditional.image/actions/runs/14660882651) succeeded.